### PR TITLE
Updated Bans.lua - Fixed PAC not unwearing on banned users sometimes.

### DIFF
--- a/lua/pac3/editor/server/bans.lua
+++ b/lua/pac3/editor/server/bans.lua
@@ -1,31 +1,33 @@
-
 function pace.Ban(ply)
 
 	ply:ConCommand("pac_clear_parts")
-
-	umsg.Start("pac_submit_acknowledged", ply)
-		umsg.Bool(false)
-		umsg.String("You have been banned from using pac!")
-	umsg.End()
 	
-	local fil = file.Read("pac_bans.txt", "DATA")
+	timer.Simple( 1, function() -- made it a timer because the ConCommand din't run fast enough. - Bizzclaw
 	
-	local bans = {}
-	if fil and fil ~= "" then
+		umsg.Start("pac_submit_acknowledged", ply)
+			umsg.Bool(false)
+			umsg.String("You have been banned from using pac!")
+		umsg.End()
+	
+		local fil = file.Read("pac_bans.txt", "DATA")
+	
+		local bans = {}
+		if fil and fil ~= "" then
 		bans = util.KeyValuesToTable(fil)
-	end
-		
-	for name, steamid in pairs(bans) do
-		if ply:SteamID() == steamid then
-			bans[name] = nil
 		end
-	end
+		
+		for name, steamid in pairs(bans) do
+			if ply:SteamID() == steamid then
+			bans[name] = nil
+			end
+		end
 
-	bans[ply:Nick():lower():gsub("%A", "")] = ply:SteamID()
+		bans[ply:Nick():lower():gsub("%A", "")] = ply:SteamID()
 	
-	pace.Bans = bans
+		pace.Bans = bans
 	
-	file.Write("pac_bans.txt", util.TableToKeyValues(bans), "DATA")
+		file.Write("pac_bans.txt", util.TableToKeyValues(bans), "DATA")
+	end)
 end
 
 function pace.Unban(ply)


### PR DESCRIPTION
Not much here, I just noticed that when sometimes people where banned from PAC, it wouldn't remove their outfit even though it clearly ran the "Clear Parts" command on them. Simply making a one second delay ensured that the Part clearing process would complete properly. Tested and working.
