### PR TITLE
Event: Find entity in a box using specified class/radius

### DIFF
--- a/lua/pac3/core/client/parts/event.lua
+++ b/lua/pac3/core/client/parts/event.lua
@@ -125,7 +125,7 @@ PART.Events =
 	box_entity_class =
 	{
 		arguments = {{class = "string"}, {radius = "number"}},
-		callback = function(self, ent, class)
+		callback = function(self, ent, class, radius)
 			local entities = {}
 			for k,v in pairs(ents.FindInBox(ent:GetPos(),Vector(radius,radius,radius) or Vector(0,0,0)) do
 				if IsValid(v) and v:GetClass() == class then


### PR DESCRIPTION
You can specify an entity class to search for, and the radius of the box in which it'll search those.
