### PR TITLE
Add Sign Function, Define ceil, floor, pi

### DIFF
--- a/lua/pac3/core/client/libraries/expression.lua
+++ b/lua/pac3/core/client/libraries/expression.lua
@@ -31,6 +31,7 @@ local lib =
 	sqrt = math.sqrt,
 	tanh = math.tanh,
 	tan = math.tan,
+	sgn = function(n) return n>0 and 1 or n<0 and -1 or 0 end,
 	
 	clamp = math.Clamp,
 }

--- a/lua/pac3/core/client/parts/proxy.lua
+++ b/lua/pac3/core/client/parts/proxy.lua
@@ -71,9 +71,6 @@ PART.Functions =
 	abs = math.abs,
 	mod = function(n, s) return n%s.Max end,
 	sgn = function(n) return n>0 and 1 or n<0 and -1 or 0 end,
-	ceil = math.ceil,
-	floor = math.floor,
-	pi = math.pi,
 }
 
 local FrameTime = FrameTime


### PR DESCRIPTION
Adds sign function sgn(n) that returns -1, 0, or 1 depending on sign of
n. Defines math.ceil, math.floor, and math.pi as ceil(), floor(), and
pi(), respectively.
