### PR TITLE
Add 'Reset On Hide' to Animation part 

### DIFF
--- a/lua/pac3/core/client/parts/animation.lua
+++ b/lua/pac3/core/client/parts/animation.lua
@@ -16,6 +16,7 @@ pac.StartStorableVars()
 	pac.GetSet(PART, "Max", 1)
 	pac.GetSet(PART, "WeaponHoldType", "none")
 	pac.GetSet(PART, "OwnerCycle", false)
+	pac.GetSet(PART, "ResetOnHide", true)
 pac.EndStorableVars()
 
 
@@ -101,7 +102,7 @@ function PART:OnHide()
 			ent.pac_animation_holdtypes[self] = nil
 		end
 		
-		if not ent:IsPlayer() then
+		if not ent:IsPlayer() and self:GetResetOnHide() then
 			ent:SetSequence(0)
 		end
 	end


### PR DESCRIPTION
Adds a 'Reset On Hide' checkbox to the animation part, that is checked
by default. When unchecked, the model's sequence is not set to 0 when
the animation part is hidden. This lets users switch between sequences
with events fluidly.

Not sure why robotboy's month-old commit is getting pulled along with this, I might be syncing my fork with upstream incorrectly
