### PR TITLE
Add pace tool "square model scales"

### DIFF
--- a/lua/pac3/editor/client/tools.lua
+++ b/lua/pac3/editor/client/tools.lua
@@ -98,6 +98,27 @@ pace.AddTool(L"scale this and children", function(part, suboption)
 	end)
 end)
 
+pace.AddTool(L"square model scales...", function(part, suboption)
+	Derma_StringRequest(L"model", L"input the model name that should get squared", "default.mdl", function(model)
+		for _, part in pairs(pac.GetParts(true)) do
+			if part:IsValid() and part.GetModel then
+				local function square_scale(part)	
+					if part.SetSize then 
+						part:SetSize(part:GetSize() * part:GetSize()) 
+					end 
+							
+					if part.SetScale then
+						part:SetScale(part:GetScale() * part:GetScale())
+					end
+				end
+				if string.find(part:GetModel(),model) then
+					square_scale(part)
+				end
+			end			
+		end
+	end)
+end)
+
 pace.AddTool(L"show only with active weapon", function(part, suboption)
 	local event = part:CreatePart("event")
 	local owner = part:GetOwner(true)


### PR DESCRIPTION
Adds a pace tool that will square the scales of all parts who have a
Model field selectively if that field contains a given string. This tool
will help repair costumes that were created between Apr 04 2014 and July
08 2014 that did not use legacy scale. A filter is being used to select
which models to scale because not all models will need to be scaled back
(in many cases, only default.mdl will be- which is why it is the default
string).
