### PR TITLE
Add pace tools that import pace tools

### DIFF
--- a/lua/pac3/editor/client/tools.lua
+++ b/lua/pac3/editor/client/tools.lua
@@ -117,7 +117,8 @@ pace.AddTool(L"show only with active weapon", function(part, suboption)
 end, L"hide weapon", L"show weapon")
 
 pace.AddTool(L"import editor tool from file...", function()
-	if LocalPlayer():IsSuperAdmin() then
+	local allowcslua = GetConVar("sv_allowcslua")
+	if allowcslua:GetBool() then
 		Derma_StringRequest(L"filename", L"relative to garrysmod/data/pac3_editor/tools/", "mytool.txt", function(toolfile)
 			if file.Exists("pac3_editor/tools/"..toolfile,"DATA") then
 				local toolstr = file.Read("pac3_editor/tools/"..toolfile,"DATA")
@@ -129,12 +130,13 @@ pace.AddTool(L"import editor tool from file...", function()
 			end
 		end)
 	else
-		Derma_Message("You must be a superadmin to import pac editor tools.","Error: Access Denied","OK")
+		Derma_Message("Importing pac editor tools is disallowed on this server.","Error: Clientside Lua Disabled","OK")
 	end
 end)
 
 pace.AddTool(L"import editor tool from url...", function()
-	if LocalPlayer():IsSuperAdmin() then
+	local allowcslua = GetConVar("sv_allowcslua")
+	if allowcslua:GetBool() then
 		Derma_StringRequest(L"URL", L"URL to PAC Editor tool txt file", "http://www.example.com/tool.txt", function(toolurl)
 		function ToolDLSuccess(body)
 			local toolname = pac.PrettifyName(toolurl:match(".+/(.-)%."))
@@ -149,7 +151,7 @@ pace.AddTool(L"import editor tool from url...", function()
 		http.Fetch(toolurl,ToolDLSuccess,ToolDLFail)
 		end)
 	else
-		Derma_Message("You must be a superadmin to import pac editor tools.","Error: Access Denied","OK")
+		Derma_Message("Importing pac editor tools is disallowed on this server.","Error: Clientside Lua Disabled","OK")
 	end
 end)
 


### PR DESCRIPTION
Yo dawg...

Adds pace tools that allow superadmins to import pace tools from a local
file or an external URL. It only imports them into the editor of the
client who ran them.

(The superadmin restriction is present to deter people from stealing
other's pac costumes. It's obviously still possible, but I don't want
this to make it any easier to do. In singleplayer the local player is a
superadmin so they can still use it there.)

See the following gist for some example importable pace tools:

https://gist.github.com/suchipi/632a3bfb8a29269c1ddb
