### PR TITLE
Update animation editor

### DIFF
--- a/lua/pac3/core/client/netmessages.lua
+++ b/lua/pac3/core/client/netmessages.lua
@@ -3,3 +3,31 @@ net.Receive( "pac.net.TogglePartDrawing", function( length, client )
 		b = (net.ReadBit() == 1)
 		if ent:IsValid() then pac.TogglePartDrawing(ent, b) end
 end )
+
+function pac.SetInPAC3Editor(b)
+	net.Start("pac.net.InPAC3Editor.ClientNotify")
+	net.WriteBit(b)
+	net.SendToServer()
+end
+
+net.Receive( "pac.net.InPAC3Editor", function( length, client )
+    ent = net.ReadEntity()
+	b = (net.ReadBit() == 1)
+	if ent:IsValid() then 
+		ent.InPAC3Editor = b
+	end
+end )
+
+function pac.SetInAnimEditor(b)
+	net.Start("pac.net.InAnimEditor.ClientNotify")
+	net.WriteBit(b)
+	net.SendToServer()
+end
+
+net.Receive( "pac.net.InAnimEditor", function( length, client )
+    ent = net.ReadEntity()
+	b = (net.ReadBit() == 1)
+	if ent:IsValid() then 
+		ent.InAnimEditor = b
+	end
+end )

--- a/lua/pac3/core/server/netmessages.lua
+++ b/lua/pac3/core/server/netmessages.lua
@@ -9,3 +9,23 @@ function pac.TogglePartDrawing(ent, b, who) --serverside interface to clientside
 		net.Send(who)
 	end
 end
+
+util.AddNetworkString("pac.net.InPAC3Editor")
+util.AddNetworkString("pac.net.InPAC3Editor.ClientNotify")
+net.Receive( "pac.net.InPAC3Editor.ClientNotify", function( length, client )
+	b = (net.ReadBit() == 1)
+	net.Start("pac.net.InPAC3Editor")
+	net.WriteEntity(client)
+	net.WriteBit(b)
+	net.Broadcast()
+end )
+
+util.AddNetworkString("pac.net.InAnimEditor")
+util.AddNetworkString("pac.net.InAnimEditor.ClientNotify")
+net.Receive( "pac.net.InAnimEditor.ClientNotify", function( length, client )
+	b = (net.ReadBit() == 1)
+	net.Start("pac.net.InAnimEditor")
+	net.WriteEntity(client)
+	net.WriteBit(b)
+	net.Broadcast()
+end )

--- a/lua/pac3/editor/client/animeditor.lua
+++ b/lua/pac3/editor/client/animeditor.lua
@@ -64,6 +64,17 @@ boneList["ValveBiped"] = {
 	"ValveBiped.bone2"
 	
 }
+local function ParseBones(ent)
+	local thisbone = -1
+	local bonetbl = {}
+	if ent:GetBoneCount() == nil then return {} end
+	while thisbone < ent:GetBoneCount() do
+		thisbone = thisbone + 1
+		realname = ent:GetBoneName(thisbone)
+		if realname ~= "__INVALIDBONE__" then table.insert(bonetbl,realname) end
+	end
+	return bonetbl
+end
 
 local animationData = {}
 
@@ -271,15 +282,30 @@ local function NewAnimation()
 	type:AddChoice("TYPE_STANCE", TYPE_STANCE)
 	type:AddChoice("TYPE_SEQUENCE", TYPE_SEQUENCE, true)
 	local help = form:Help("Select your options")
+	help:SetColor(Color(255,255,255))
 	local begin = form:Button("Begin")
 	begin.DoClick = function()
 		animName = entry:GetValue()
 		animType = _G[type:GetText()]
 		
-		if animName == "" then help:SetText("Write a name for this animation") return end
-		if !animType then help:SetText("Select a valid animation type!") return end
-		frame:Remove()
-		AnimationStarted()
+		if animName == "" then 
+			help:SetColor(Color(255,128,128))
+			help:SetText("Write a name for this animation") 
+			surface.PlaySound("ui/buttonrollover.wav")
+			return 
+		end
+		if !animType then 
+			help:SetColor(Color(255,128,128))
+			help:SetText("Select a valid animation type!") 
+			surface.PlaySound("ui/buttonrollover.wav")
+			return 
+		end
+		if (animType ~= nil) and (animName ~= nil) then --don't move on until these are set
+		  if animType == TYPE_SEQUENCE then pace.SetTPose(true) end
+		  if animType ~= TYPE_SEQUENCE then pace.SetTPose(false) end
+		  frame:Remove()
+		  AnimationStarted()
+		end
 	end
 	frame:MakePopup()
 	
@@ -294,10 +320,11 @@ local function LoadAnimation()
 	local box = vgui.Create("DComboBox",frame)
 	--box:SetMultiple(false) adurp
 	box:StretchToParent(5,25,5,35)
-	
 	for i,v in pairs(GetLuaAnimations()) do
 		if i != "editortest" && i != "editingAnim" && !string.find(i,"subPosture_") then --anim editor uses this internally
-			box:AddChoice(i)
+			if !string.find(i,"pac_anim_") then --animations made by custom_animation parts shouldn't be here
+				box:AddChoice(i)
+			end
 		end
 	end
 	
@@ -310,6 +337,8 @@ local function LoadAnimation()
 		animName = box:GetText()
 		animationData = GetLuaAnimations()[animName] or {}
 		animType = animationData.Type
+		if animType == TYPE_SEQUENCE then pace.SetTPose(true) end
+		if animType ~= TYPE_SEQUENCE then pace.SetTPose(false) end
 		frame:Remove()
 		AnimationStarted(true)
 		LocalPlayer():StopAllLuaAnimations()
@@ -543,6 +572,9 @@ local function LoadAnimationFromFile()
 		animName = name
 		animationData = GetLuaAnimations()[animName] or {}
 		animType = animationData.Type
+		
+		if animType == TYPE_SEQUENCE then pace.SetTPose(true) end
+		if animType ~= TYPE_SEQUENCE then pace.SetTPose(false) end
 		frame:Remove()
 		AnimationStarted(true)
 		LocalPlayer():StopAllLuaAnimations()
@@ -679,15 +711,23 @@ local function AnimationEditorView(pl,origin,angles,fov)
 end
 
 local function AnimationEditorOff()
-	
-	for i,v in pairs(animEditorPanels) do 
+--I want to eventually create a "save unsaved changes" dialog box when you close
+	if(!file.Exists("animations/backups","DATA")) then file.CreateDir"animations/backups" end
+	local convertedjson = util.TableToJSON(animationData)
+	if convertedjson then
+		file.Write("animations/backups/previous_session_"..os.date("%m%d%y%H%M%S")..".txt", convertedjson)
+	end
+	for i,v in pairs(animEditorPanels) do 	
 		v:Remove()
 	end
+	pac.SetInAnimEditor(false)
 	hook.Remove("HUDPaint","PaintTopBar")
 	hook.Remove("CalcView","AnimationView")
 	hook.Remove("Think","FixMouse")
 	hook.Remove("ShouldDrawLocalPlayer","DrawMe")
+	pace.SetTPose(false)
 	LocalPlayer():StopAllLuaAnimations()
+	LocalPlayer():ResetBoneMatrix()
 	gui.EnableScreenClicker(false)
 	animating = false
 	animName = nil
@@ -697,16 +737,18 @@ local function AnimationEditorOff()
 end
 
 local function AnimationEditorOn()
-	if not LocalPlayer():IsSuperAdmin() and not game.SinglePlayer() then return end
+	--if not LocalPlayer():IsSuperAdmin() and not game.SinglePlayer() then return end
 
 	if animating then AnimationEditorOff() return end
 	for i,v in pairs(animEditorPanels) do 
 		v:Remove()
 	end
 	
+	--RunConsoleCommand("animeditor_in_editor", "1")
+	pac.SetInAnimEditor(true)
 	
 	local close = vgui.Create("DButton")
-	close:SetText("C")
+	close:SetText("X")
 	close.DoClick = function(slf) AnimationEditorOff() end
 	close:SetSize(16,16)
 	close:SetPos(4,4)
@@ -764,6 +806,8 @@ function MAIN:Init()
 	self:SetName("Main Settings")
 	self:SetSize(200,315)
 	self:SetPos(0,22)
+	
+	boneList["ParsedSkeleton"] = ParseBones(LocalPlayer())
 	
 	local newanim = self:Button("New Animation")
 	newanim.DoClick = NewAnimation
@@ -859,15 +903,17 @@ function TIMELINE:Init()
 			
 
 			local subtraction = 0
-			if firstPass && animationData.StartFrame then
-				for i=1,animationData.StartFrame do
-					local v = animationData.FrameData[i]
-					subtraction = subtraction+(1/(v.FrameRate or 1))
-				end
-			elseif !firstPass && animationData.RestartFrame then
-				for i=1,animationData.RestartFrame do
-					local v = animationData.FrameData[i]
-					subtraction = subtraction+(1/(v.FrameRate or 1))
+			if animationData then
+				if firstPass && animationData.StartFrame then
+					for i=1,animationData.StartFrame do
+						local v = animationData.FrameData[i]
+						subtraction = subtraction+(1/(v.FrameRate or 1))
+					end
+				elseif !firstPass && animationData.RestartFrame then
+					for i=1,animationData.RestartFrame do
+						local v = animationData.FrameData[i]
+						subtraction = subtraction+(1/(v.FrameRate or 1))
+					end
 				end
 			end
 
@@ -1306,6 +1352,7 @@ function KEYFRAME:OnMousePressed(mc)
 				data.BoneInfo[i].RR = v.RR
 				data.BoneInfo[i].RF = v.RF
 			end
+			keyframe:SetLength(1/(self:GetData().FrameRate))
 			sliders:SetFrameData()
 
 			--[[local tbl = animationData.FrameData
@@ -1350,6 +1397,7 @@ vgui.Register("AnimEditor_KeyFrame",KEYFRAME,"DPanel")
 local SLIDERS = {}
 function SLIDERS:Init()
 	self:SetName("Modify Bone")
+	self:SetMinimumSize(200,650)
 	self:SetWide(200)
 	self.Sliders = {}
 	
@@ -1478,19 +1526,32 @@ function SUBANIMS:Refresh()
 		
 		--no need to show these
 		if i != "editortest" && i != animName && i != "editingAnim" && !string.find(i,"subPosture_") then
-			local item = self.AnimList:AddChoice(i)
-			--[[local item = self.AnimList:AddItem(i)
-			item.DoClick = function() 
-				self.SelectedAnim = i
-				if subAnimationsLoaded[i] then
-					self.AddButton:SetText("Remove Animation")
-				else
-					self.AddButton:SetText("Add Animation")
-				end
-					
-			end]]
+			if !string.find(i,"pac_anim_") then --animations made by custom_animation parts shouldn't be here
+				local item = self.AnimList:AddChoice(i)
+				--[[local item = self.AnimList:AddItem(i)
+				item.DoClick = function() 
+					self.SelectedAnim = i
+					if subAnimationsLoaded[i] then
+						self.AddButton:SetText("Remove Animation")
+					else
+						self.AddButton:SetText("Add Animation")
+					end
+						
+				end]]
+			end
 		end
 	end
 	
 end
 vgui.Register("AnimEditor_SubAnimations",SUBANIMS,"DFrame")
+
+hook.Add("HUDPaint", "animeditor_InAnimEditor", function()		
+	for key, ply in pairs(player.GetAll()) do
+		if ply ~= LocalPlayer() and ply.InAnimEditor then
+			local id = ply:LookupBone("ValveBiped.Bip01_Head1")
+			local pos_3d = id and ply:GetBonePosition(id) or ply:EyePos()
+			local pos_2d = (pos_3d + Vector(0,0,10)):ToScreen()
+			draw.DrawText("In Animation Editor", "ChatFont", pos_2d.x, pos_2d.y, Color(255,255,255,math.Clamp((pos_3d + Vector(0,0,10)):Distance(EyePos()) * -1 + 500, 0, 500)/500*255),1)
+		end
+	end
+end)

--- a/lua/pac3/editor/client/init.lua
+++ b/lua/pac3/editor/client/init.lua
@@ -132,7 +132,8 @@ function pace.OpenEditor()
 		ctp:Disable()
 	end
 	
-	RunConsoleCommand("pac_in_editor", "1")
+	--RunConsoleCommand("pac_in_editor", "1")
+	pac.SetInPAC3Editor(true)
 	
 	pace.DisableExternalHooks()
 	
@@ -149,7 +150,8 @@ function pace.CloseEditor()
 		pace.Call("CloseEditor") 
 	end
 	
-	RunConsoleCommand("pac_in_editor", "0")
+	--RunConsoleCommand("pac_in_editor", "0")
+	pac.SetInPAC3Editor(false)
 end
 
 hook.Add("pace_Disable", "pac_editor_disable", function()
@@ -240,7 +242,7 @@ end
 
 hook.Add("HUDPaint", "pac_InPAC3Editor", function()		
 	for key, ply in pairs(player.GetAll()) do
-		if ply ~= LocalPlayer() and ply:GetNWBool("in pac3 editor") then
+		if ply ~= LocalPlayer() and ply.InPAC3Editor then
 			local id = ply:LookupBone("ValveBiped.Bip01_Head1")
 			local pos_3d = id and ply:GetBonePosition(id) or ply:EyePos()
 			local pos_2d = (pos_3d + Vector(0,0,10)):ToScreen()


### PR DESCRIPTION
This commit makes several changes:

-Remove console command "pac_in_editor" and use the net library to
transmit this information instead (this is used for the overhead "In
Editor" text).

-Replicate this behavior within the Animation Editor.

-Add a "Parsed Skeleton" option to the animation editor that allows
users to use any bone structure their current player entity has.

-Disallow creating an animation without a name, which would cause errors
later on.

-Don't display boneanimlib animations that were created by the
custom_animation pac part

-When editing a sequence, t-pose the player so the user has a proper
frame of reference

-Automatically save backups of the current animation when the editor is
closed

-Allow any user to use the animation editor

-Preserve frame length when cloning a keyframe

-Various bugfixes
