### PR TITLE
Add animation part option "Reset on hide"

### DIFF
--- a/lua/pac3/core/client/parts/animation.lua
+++ b/lua/pac3/core/client/parts/animation.lua
@@ -16,6 +16,7 @@ pac.StartStorableVars()
 	pac.GetSet(PART, "Max", 1)
 	pac.GetSet(PART, "WeaponHoldType", "none")
 	pac.GetSet(PART, "OwnerCycle", false)
+	pac.GetSet(PART, "ResetOnHide", true)
 pac.EndStorableVars()
 
 
@@ -101,7 +102,7 @@ function PART:OnHide()
 			ent.pac_animation_holdtypes[self] = nil
 		end
 		
-		if not ent:IsPlayer() then
+		if not ent:IsPlayer() and self:GetResetOnHide() then
 			ent:SetSequence(0)
 		end
 	end


### PR DESCRIPTION
When unchecked, the animation part will not set its parent entity to
sequence 0 on hide, allowing users to switch between two sequences
fluidly using two animation parts with events. Default is checked to
retain prior behaviour on existing costumes.
