### PR TITLE
Add some hooks into pac part logic

### DIFF
--- a/lua/pac3/core/client/base_part.lua
+++ b/lua/pac3/core/client/base_part.lua
@@ -632,7 +632,9 @@ do -- serializing
 			if key == "AimPartName" and not table.HasValue(pac.AimPartNames, value) then
 				continue
 			end
-						
+			
+			self = hook.Run("pac_PART:SetTable",self,key,value) or self
+			
 			if self["Set" .. key] then	
 				-- hacky
 				if key:find("Name", nil, true) and key ~= "OwnerName" and key ~= "SequenceName" and key ~= "VariableName" then

--- a/lua/pac3/core/client/parts/model.lua
+++ b/lua/pac3/core/client/parts/model.lua
@@ -505,7 +505,9 @@ function PART:SetModel(var)
 	end
 	
 	self.wavefront_mesh = nil
-	
+		
+		var = hook.Run("pac_model:SetModel",self,var) or var
+		
 		self.Model = var
 		self.Entity.pac_bones = nil
 		self.Entity:SetModel(var)

--- a/lua/pac3/editor/client/saved_parts.lua
+++ b/lua/pac3/editor/client/saved_parts.lua
@@ -33,6 +33,8 @@ function pace.SaveParts(name, prompt_name, override_part)
 				end
 			end
 		end
+		
+		data = hook.Run("pac_pace.SaveParts",data) or data
 				
 		file.CreateDir("pac3")
 		file.CreateDir("pac3/__backup/")


### PR DESCRIPTION
Adds three hooks that can be used to write pac parts with specialized
logic:

"pac_PART:SetTable" is run for each key/value pair a part is getting
from the table passed to SetTable. This most notably occurs when the pac
editor loads parts from file

"pac_model:SetModel" is run when a model part is about to set its model

"pac_pace.SaveParts" is run when the editor has constructed a table
representing the parts and is about to save it to file

(the vfs part uses these hooks)
