### PR TITLE
Add hook for pac editor config

### DIFF
--- a/lua/pac3/editor/client/config.lua
+++ b/lua/pac3/editor/client/config.lua
@@ -662,3 +662,5 @@ end
 function pace.GetIconFromClassName(class_name)
 	return pace.PartIcons[class_name] or "gui/silkicons/plugin"
 end
+
+hook.Run("pac_pace_postconfig")


### PR DESCRIPTION
Add a hook that runs at the bottom of pace's config.lua so that custom
parts can setup their editor config (location in tree, icon, etc) at the appropriate time