### PR TITLE
Removed Dump SubMaterials

### DIFF
--- a/lua/pac3/editor/client/tools.lua
+++ b/lua/pac3/editor/client/tools.lua
@@ -424,13 +424,6 @@ pace.AddTool("print part info",function(part)
 	PrintTable(part:ToTable())
 end)
 
-pace.AddTool("dump player submaterials",function()
-	local ply = LocalPlayer()
-	for id,mat in pairs(ply:GetMaterials()) do
-		chat.AddText(("%d %s"):format(id,tostring(mat)))
-	end
-end)
-
 pace.AddTool("stop all custom animations",function()
 	LocalPlayer():StopAllLuaAnimations()
 	LocalPlayer():ResetBoneMatrix()


### PR DESCRIPTION
SetSubMaterial support is gone from this repo, so why even keep the tool in the editor?