### PR TITLE
Fix comment format in global_bans.lua

### DIFF
--- a/lua/pac3/editor/server/global_bans.lua
+++ b/lua/pac3/editor/server/global_bans.lua
@@ -1,4 +1,4 @@
---[[ 
+--[==[ 
 
 This used to be uncommented for a long time but I don't believe it's ethical anymore.
 Bans should be between servers.
@@ -21,4 +21,4 @@ pace.GlobalBans = {
 		he has been called out for it countless of times and being an asshole about it at the same time.
 	]],
 }
-]]
+]==]


### PR DESCRIPTION
The end of the string ]] on line 17 was being interpreted as the end of the comment block, so the rest of the file was being parsed and erroring.