### PR TITLE
Make the editor tool "populate with dummy bones" useful

### DIFF
--- a/lua/pac3/editor/client/tools.lua
+++ b/lua/pac3/editor/client/tools.lua
@@ -412,7 +412,8 @@ pace.AddTool(L"populate with dummy bones",function(part,suboption)
 		if not tbl.is_special then 
 			local child = pac.CreatePart("model")
 			child:SetParent(part)
-			child:SetName(bone)
+			child:SetName(bone.."_dummy")
+			child:SetBone(bone)
 			child:SetScale(Vector(0,0,0))
 		end
 	end


### PR DESCRIPTION
I wrote this pac editor tool ages ago to assist with manual bone merging, but just realized it wasn't doing everything it should. 
With this PR, new dummy bones created by this tool also:
* Follow the bone they are acting as a dummy of (how did I miss this?)
* Have a name suffixed with `_dummy` to keep follow parts unambiguous

For reference to future readers, to use these tools to do a manual model-to-player bonemerge, just:
*  Create a group for the dummy bones and click on it in the tree
*  Click on tools -> populate with dummy bones
*  Add the model you want to bonemerge to your player to the root group
*  Set your model bone to "invalidbone" so it shares its origin with the player model's
*  Click your model and hit tools -> populate with bones
*  For each bone in your model, set its follow part to the appropriate "_dummy" part
*  Rotate your dummy bones to properly orient the model you are bonemerging on.