### PR TITLE
Fix OGG playback for poorly manufactured headsets

### DIFF
--- a/lua/pac3/core/client/init.lua
+++ b/lua/pac3/core/client/init.lua
@@ -19,7 +19,7 @@ include("libraries/urlobj/urlobj.lua")
 include("libraries/urlobj/queueitem.lua")
 
 -- WebAudio
-include("libraries/webaudio/oggfix.lua")
+include("libraries/webaudio/ogg_fix.lua")
 include("libraries/webaudio/urlogg.lua")
 include("libraries/webaudio/browser.lua")
 include("libraries/webaudio/stream.lua")

--- a/lua/pac3/core/client/init.lua
+++ b/lua/pac3/core/client/init.lua
@@ -19,10 +19,11 @@ include("libraries/urlobj/urlobj.lua")
 include("libraries/urlobj/queueitem.lua")
 
 -- WebAudio
+include("libraries/webaudio/oggfix.lua")
 include("libraries/webaudio/urlogg.lua")
 include("libraries/webaudio/browser.lua")
 include("libraries/webaudio/stream.lua")
-include("libraries/webaudio/streams.lua")
+include("libraries/webaudio/streams.lua") 
 
 include("libraries/boneanimlib.lua")
 
@@ -32,6 +33,7 @@ include("parts.lua")
 include("bones.lua")
 include("hooks.lua")
 include("drawing.lua")
+
 
 include("owner_name.lua")
 

--- a/lua/pac3/core/client/libraries/webaudio/ogg_fix.lua
+++ b/lua/pac3/core/client/libraries/webaudio/ogg_fix.lua
@@ -1,0 +1,100 @@
+// Hacky fix for oggs.
+// The problem is not completely bass, its also holly_ogg.dll.
+// If we stream them directly from the disk, then they work.
+
+local ogg = {}
+ogg.debug = false
+ogg.enabled = false 
+
+
+if !file.Exists("scache/","DATA") then
+    file.CreateDir("scache")
+end
+
+
+function ogg.Download(url,callback,nocache)
+    local urlsum  = os.time() ..  util.CRC(url)
+    if not nocache then 
+        if file.Exists("scache/"  .. urlsum .. ".txt", "DATA") then 
+            callback(true, urlsum,"200")
+            return true
+        end
+    end
+
+    http.Fetch( url,
+        function( body, len, headers, code )
+            file.Write("scache/" .. urlsum .. ".txt",body)
+            if debug then 
+               MsgC(Color(255,255,0),"[OGG]: WRITE - > ") MsgC(Color(255,0,0), urlsum .. ".txt \n" )
+            end
+            callback(true,urlsum,code)
+        end,
+        function( error )
+            callback(false,nil,error)
+        end
+    );
+end
+function ogg.enable(enabled)
+    if enabled then 
+        ogg.enabled = true 
+        if sound._OldPlayURL then 
+                sound.PlayURL = sound._OldPlayURL
+        end
+        sound._OldPlayURL = sound.PlayURL
+        function sound.PlayURL(url,args,func,median)
+            if median then 
+                print(url,args,func)
+                assert(type(func)=="function","Argument #3 to sound.PlayURL. Function expected, got " .. type(func))
+                assert(type(url)=="string","Argument #1 to sound.PlayURL. String expected, got " .. type(url))
+                assert(type(args)=="string","Argument #2 to sound.PlayURL. String expected, got " .. type(args))
+                
+                ogg.Download(url,function(succ,fname,err)
+                    if not succ then
+                        func(nil,0xFFF,"HTTP ERROR .. err")
+                    end
+                    if succ then 
+                        sound.PlayFile("data/scache/" .. fname .. ".txt",args,func)            
+                    end
+                
+                end)
+            else
+                sound._OldPlayURL(url,args,func)
+                
+            end
+        end
+    else 
+        ogg.enabled = false
+        if sound._OldPlayURL then 
+            sound.PlayURL = sound._OldPlayURL
+            sound._OldPlayURL = nil
+        end
+    end
+
+end
+
+
+ogg.cvar = CreateConVar( "pac_ogg_fix", "0", FCVAR_ARCHIVE , "Enable the broken fix for OGG Streaming") 
+
+
+cvars.AddChangeCallback( "pac_ogg_fix", function( convar_name, value_old, value_new )
+    if convar_name = "pac_ogg_fix" then 
+            if tonumber(value_new)==1 then 
+                ogg.enable(true)
+            else
+                ogg.enable(false)
+            end
+    end
+end )
+
+
+timer.Simple(0,function()
+        ogg.enable(ogg.cvar:GetBool())
+end)
+
+
+
+
+pac.oggfix = ogg
+
+
+

--- a/lua/pac3/core/client/libraries/webaudio/ogg_fix.lua
+++ b/lua/pac3/core/client/libraries/webaudio/ogg_fix.lua
@@ -24,7 +24,7 @@ function ogg.Download(url,callback,nocache)
     http.Fetch( url,
         function( body, len, headers, code )
             file.Write("scache/" .. urlsum .. ".txt",body)
-            if debug then 
+            if ogg.debug then 
                MsgC(Color(255,255,0),"[OGG]: WRITE - > ") MsgC(Color(255,0,0), urlsum .. ".txt \n" )
             end
             callback(true,urlsum,code)
@@ -43,7 +43,9 @@ function ogg.enable(enabled)
         sound._OldPlayURL = sound.PlayURL
         function sound.PlayURL(url,args,func,median)
             if median then 
-                print(url,args,func)
+                if ogg.debug then
+                        print(url,args,func)
+                end
                 assert(type(func)=="function","Argument #3 to sound.PlayURL. Function expected, got " .. type(func))
                 assert(type(url)=="string","Argument #1 to sound.PlayURL. String expected, got " .. type(url))
                 assert(type(args)=="string","Argument #2 to sound.PlayURL. String expected, got " .. type(args))
@@ -77,7 +79,7 @@ ogg.cvar = CreateConVar( "pac_ogg_fix", "0", FCVAR_ARCHIVE , "Enable the broken 
 
 
 cvars.AddChangeCallback( "pac_ogg_fix", function( convar_name, value_old, value_new )
-    if convar_name = "pac_ogg_fix" then 
+    if convar_name == "pac_ogg_fix" then 
             if tonumber(value_new)==1 then 
                 ogg.enable(true)
             else

--- a/lua/pac3/core/client/parts/webaudio.lua
+++ b/lua/pac3/core/client/parts/webaudio.lua
@@ -126,7 +126,7 @@ function PART:SetURL(URL)
 			self.streams[url] = snd
 		end
 		
-		sound.PlayURL(url, flags, callback)
+		sound.PlayURL(url, flags, callback,pac.oggfix.enabled)
 		
 	end
 	


### PR DESCRIPTION
Adds a CVAR to fix OGG playback for the unfortunate people who bought headsets like the G930 or people who simply have incompatible soundcards.

The problem was never playing oggs through BASS, it was streaming them over URL.

The CVAR will cause PAC to download the entire file and play it from the disk (which is why this is optional and isabled by default)