### PR TITLE
Fix pace.Restore/DisableExternalHooks not handling entity hooks properly

### DIFF
--- a/lua/pac3/editor/client/init.lua
+++ b/lua/pac3/editor/client/init.lua
@@ -200,7 +200,7 @@ do -- forcing hooks
 				pace.OldHooks[event] = table.Copy(hooks)
 
 				for name in pairs(hooks) do
-					if isstring(name) and name:sub(1, 4) ~= "pace_" then
+					if type(name) == "string" and name:sub(1, 4) ~= "pace_" then
 						hook.Remove(event, name)
 					end
 				end
@@ -212,7 +212,7 @@ do -- forcing hooks
 		if pace.OldHooks then
 			for event, hooks in pairs(pace.OldHooks) do
 				for name, func in pairs(hooks) do
-					if isstring(name) and name:sub(1, 4) ~= "pace_" then
+					if type(name) == "string" and name:sub(1, 4) ~= "pace_" then
 						hook.Add(event, name, func)
 					end
 				end

--- a/lua/pac3/editor/client/init.lua
+++ b/lua/pac3/editor/client/init.lua
@@ -200,7 +200,7 @@ do -- forcing hooks
 				pace.OldHooks[event] = table.Copy(hooks)
 
 				for name in pairs(hooks) do
-					if name:sub(1, 4) ~= "pace_" then
+					if isstring(name) and name:sub(1, 4) ~= "pace_" then
 						hook.Remove(event, name)
 					end
 				end
@@ -212,7 +212,7 @@ do -- forcing hooks
 		if pace.OldHooks then
 			for event, hooks in pairs(pace.OldHooks) do
 				for name, func in pairs(hooks) do
-					if name:sub(1, 4) ~= "pace_" then
+					if isstring(name) and name:sub(1, 4) ~= "pace_" then
 						hook.Add(event, name, func)
 					end
 				end


### PR DESCRIPTION
Checks that the hook identifier is a string before running substring on it