### PR TITLE
GetNoDraw() for hiding PAC when player is not drawn

### DIFF
--- a/lua/pac3/core/client/drawing.lua
+++ b/lua/pac3/core/client/drawing.lua
@@ -419,6 +419,11 @@ function pac.PostDrawOpaqueRenderables(drawdepth,drawing_skybox)
 					hide_parts(ent)
 					continue
 				end
+				
+				if ent:GetNoDraw() then
+					hide_parts(ent)
+					continue
+				end
 			
 				-- :(
 				if ent.pac_death_hide_ragdoll then


### PR DESCRIPTION
This should resolve pain for many coders when they are using ply:SetNoDraw(true) (for example, spectator or ghost, or when player enters vehicle what hides player).
Tested on our server for a long time.