### PR TITLE
Disable flashlight in 2d context to avoid crashes

### DIFF
--- a/lua/pac3/core/client/drawing.lua
+++ b/lua/pac3/core/client/drawing.lua
@@ -13,20 +13,20 @@ pac.RealTime = 0
 pac.FrameNumber = 0
 
 local sort = function(a, b)
-	if a and b then 
+	if a and b then
 		if a.DrawOrder and b.DrawOrder then
 			return a.DrawOrder < b.DrawOrder
 		end
-		
+
 		if a.part and b.part and a.part.DrawOrder and b.part.DrawOrder then
 			return a.part.DrawOrder < b.part.DrawOrder
 		end
 	end
 end
-	
+
 local function think(part)
 	if part.ThinkTime == 0 then
-		if part.last_think ~= pac.FrameNumber then 
+		if part.last_think ~= pac.FrameNumber then
 			part:Think()
 			part.last_think = pac.FrameNumber
 		end
@@ -34,7 +34,7 @@ local function think(part)
 		part:Think()
 		part.last_think = pac.RealTime + (part.ThinkTime or 0.1)
 	end
-	
+
 	for _, part in pairs(part.Children) do
 		think(part)
 	end
@@ -42,7 +42,7 @@ end
 
 local function buildbones(part)
 	part:BuildBonePositions()
-	
+
 	for _, part in pairs(part.Children) do
 		buildbones(part)
 	end
@@ -66,21 +66,21 @@ local GARBAGE = math.huge
 pac.profile_info = {}
 pac.profile = true
 
-function pac.GetProfilingData(ent)	
+function pac.GetProfilingData(ent)
 	local data = pac.profile_info[ent:EntIndex()]
-	
+
 	if data then
 		local out = {events = {}}
 		out.times_rendered = data.times_ran
-		
-		
+
+
 		for type, data in pairs(data.types) do
 			out.events[type] = {
 				average_garbage = data.total_garbage / out.times_rendered,
 				average_ms = data.total_render_time / out.times_rendered,
 			}
 		end
-		
+
 		return out
 	end
 end
@@ -93,8 +93,8 @@ local function hide_parts(ent)
 			part:SetKeyValueRecursive("shown_from_rendering", false)
 			part:SetKeyValueRecursive("draw_hidden", true)
 		end
-		
-		pac.ResetBones(ent)		
+
+		pac.ResetBones(ent)
 		ent.pac_drawing = false
 	end
 end
@@ -107,7 +107,7 @@ local function show_parts(ent)
 			part:SetKeyValueRecursive("shown_from_rendering", true)
 			part:SetKeyValueRecursive("draw_hidden", false)
 		end
-		
+
 		pac.ResetBones(ent)
 		ent.pac_drawing = true
 	end
@@ -130,28 +130,28 @@ pac.ShowEntityParts = show_parts
 pac.TogglePartDrawing = toggle_drawing_parts
 
 local function render_override(ent, type, draw_only)
-	
+
 	if pac.profile then
 		TIME = util_TimerCycle()
 		GARBAGE = collectgarbage("count")
 	end
-	
+
 	if max_render_time > 0 and ent ~= pac.LocalPlayer then
 		render_time = SysTime()
-		
+
 		if ent.pac_render_time_stop and ent.pac_render_time_stop > render_time then
 			return
 		end
 	end
 
-	
+
 	if not ent.pac_parts then
 		pac.UnhookEntityRender(ent)
 	else
 		if not draw_only then
-		
+
 			pac.ResetBones(ent)
-			
+
 			-- bones MUST be setup before drawing or else unexpected/random results might happen
 			for key, part in pairs(ent.pac_parts) do
 				if part:IsValid() then
@@ -163,18 +163,18 @@ local function render_override(ent, type, draw_only)
 				end
 			end
 		end
-		
+
 		for key, part in pairs(ent.pac_parts) do
-			if part:IsValid() then		
+			if part:IsValid() then
 				if not part:HasParent() then
-					if not draw_only then 
-						think(part) 
-					end			
+					if not draw_only then
+						think(part)
+					end
 
 					if part.OwnerName == "viewmodel" and type ~= "viewmodel" then
 						continue
 					end
-					
+
 					if part.OwnerName ~= "viewmodel" and type == "viewmodel" then
 						continue
 					end
@@ -190,38 +190,38 @@ local function render_override(ent, type, draw_only)
 	if pac.profile then
 		TIME = util_TimerCycle()
 		GARBAGE = collectgarbage("count") - GARBAGE
-		
+
 		local id = ent:EntIndex()
 		pac.profile_info[id] = pac.profile_info[id] or {types = {}, times_ran = 0}
-		pac.profile_info[id].times_ran = pac.profile_info[id].times_ran + 1		
+		pac.profile_info[id].times_ran = pac.profile_info[id].times_ran + 1
 
 		pac.profile_info[id].types[type] = pac.profile_info[id].types[type] or {}
-		
+
 		local data = pac.profile_info[id].types[type]
-		
+
 		data.total_render_time = (data.total_render_time or 0) + TIME
 		data.total_garbage = (data.total_garbage or 0) + GARBAGE
-	end	
-		
-	if max_render_time > 0 and ent ~= pac.LocalPlayer then	
+	end
+
+	if max_render_time > 0 and ent ~= pac.LocalPlayer then
 		ent.pac_render_times = ent.pac_render_times or {}
-		
+
 		local last = ent.pac_render_times[type] or 0
-		
+
 		render_time = (SysTime() - render_time) * 1000
 		last = last + ((render_time - last) * FrameTime())
 		ent.pac_render_times[type] = last
-		
+
 		if last > max_render_time then
 			ent.pac_render_time_stop = SysTime() + 2 + (math.random() * 2)
-			
+
 			hide_parts(ent)
 		end
 	end
-	
+
 	render_SetColorModulation(1,1,1)
 	render_SetBlend(1)
-	
+
 	render_MaterialOverride()
 	render_ModelMaterialOverride()
 end
@@ -233,13 +233,13 @@ function pac.RenderOverride(ent, type, draw_only)
 	if not ok then
 		print("pac3 failed to render ", tostring(ent), ":")
 		print(err)
-		
+
 		if ent == pac.LocalPlayer then
 			chat.AddText("your pac3 outfit failed to render!")
 			chat.AddText(err)
 			chat.AddText("hiding your outfit to prevent further errors")
 		end
-		
+
 		ent.pac_error = err
 		table.insert(pac.Errors, err)
 		hide_parts(ent)
@@ -250,20 +250,20 @@ end
 
 pac.firstperson_parts = pac.firstperson_parts or {}
 
-function pac.HookEntityRender(ent, part)		
+function pac.HookEntityRender(ent, part)
 	if not ent.pac_parts then
 		ent.pac_parts = {}
 	end
-	
+
 	if ent.pac_parts[part] then
-		return 
+		return
 	end
-	
+
 	pac.dprint("hooking render on %s to draw part %s", tostring(ent), tostring(part))
-	
+
 	ent.pac_parts[part] = part
-	pac.drawn_entities[ent:EntIndex()] = ent	
-	pac.profile_info[ent:EntIndex()] = nil	
+	pac.drawn_entities[ent:EntIndex()] = ent
+	pac.profile_info[ent:EntIndex()] = nil
 end
 
 function pac.UnhookEntityRender(ent, part)
@@ -271,12 +271,12 @@ function pac.UnhookEntityRender(ent, part)
 	if part and ent.pac_parts then
 		ent.pac_parts[part] = nil
 	end
-	
+
 	if ent.pac_parts and not next(ent.pac_parts) then
 		pac.drawn_entities[ent:EntIndex()] = nil
 		ent.pac_parts = nil
 	end
-	
+
 	pac.profile_info[ent:EntIndex()] = nil
 end
 
@@ -325,11 +325,16 @@ function pac.ForceRendering(b)
 		force_rendering = b
 end
 
+-- disable pop/push flashlight modes (used for stability in 2D context)
+function pac.FlashlightDisable(b)
+	pac.flashlight_disabled = b
+end
+
 -- skybox hack --
 local in_skybox = false
 
 hook.Add("PreDrawSkyBox","pac",function()
-	if in_skybox==true then 
+	if in_skybox==true then
 		hook.Remove("PreDrawSkyBox","pac")
 		in_skybox = false
 		error"in_skybox was never disabled"
@@ -340,38 +345,38 @@ hook.Add("PostDrawSkyBox","pac",function()
 	in_skybox = false
 end)
 -----------------
-	
+
 local function setup_suppress()
 	local last_framenumber = 0
 	local current_frame = 0
 	local current_frame_count = 0
-	
+
 	return function()
 		if force_rendering then
 			return false
 		end
-		
+
 		--if in_skybox then return end
-		
-		if skip_rendering then 
+
+		if skip_rendering then
 			return true
 		end
-		
+
 		if cvar_framesuppress:GetBool() then
 			local frame_number = FrameNumber()
-			
+
 			if frame_number == last_framenumber then
 				current_frame = current_frame + 1
 			else
 				last_framenumber = frame_number
-							
+
 				if current_frame_count ~= current_frame then
 					current_frame_count = current_frame
 				end
-				
+
 				current_frame = 1
 			end
-					
+
 			return current_frame < current_frame_count
 		end
 	end
@@ -388,12 +393,12 @@ local dst = 0
 --local garbage = 0
 
 local should_suppress = setup_suppress()
-function pac.PostDrawOpaqueRenderables(drawdepth,drawing_skybox)	
+function pac.PostDrawOpaqueRenderables(drawdepth,drawing_skybox)
 	if in_skybox or should_suppress() then return end
-	
+
 	--garbage = collectgarbage("count")
-	
-	-- commonly used variables		
+
+	-- commonly used variables
 	max_render_time = max_render_time_cvar:GetFloat()
 	pac.RealTime = RealTime()
 	pac.FrameNumber = FrameNumber()
@@ -402,29 +407,29 @@ function pac.PostDrawOpaqueRenderables(drawdepth,drawing_skybox)
 	fovoverride = cvar_fovoverride:GetInt()
 	sv_draw_dist = GetConVarNumber("pac_sv_draw_distance")
 	radius = 0
-	
+
 	if draw_dist == 0 then
 		draw_dist = 32768
 	end
-	
+
 	for key, ent in pairs(pac.drawn_entities) do
 		if ent:IsValid() then
 			ent.pac_pixvis = ent.pac_pixvis or util.GetPixelVisibleHandle()
 			dst = ent:EyePos():Distance(pac.EyePos)
 			radius = ent:BoundingRadius() * 3 * (ent:GetModelScale() or 1)
-			
+
 			if ent:IsPlayer() then
-				
+
 				if not ent:Alive() and GetConVarNumber("pac_sv_hide_outfit_on_death") == 1 then
 					hide_parts(ent)
 					continue
 				end
-				
+
 				if ent:GetNoDraw() then
 					hide_parts(ent)
 					continue
 				end
-			
+
 				-- :(
 				if ent.pac_death_hide_ragdoll then
 					local ply = ent
@@ -439,45 +444,45 @@ function pac.PostDrawOpaqueRenderables(drawdepth,drawing_skybox)
 							ent:SetParent(ply)
 							ent:AddEffects(EF_BONEMERGE)
 						end
-						
+
 						if ply.pac_draw_player_on_death then
 							ply:DrawModel()
 						end
 					end
 				end
-			
+
 				if radius < 32 then
 					radius = 128
 				end
 			end
-			
+
 			if not ent:IsPlayer() and not ent:IsNPC() then
 				radius = radius * 4
 			end
-			
-			if 	
+
+			if
 				draw_dist == -1 or
 				ent.IsPACWorldEntity or
 				(ent == pac.LocalPlayer and ent:ShouldDrawLocalPlayer() or (ent.pac_camera and ent.pac_camera:IsValid())) or
-				ent ~= pac.LocalPlayer and 
-				(					
-					((util_PixelVisible(ent:EyePos(), radius, ent.pac_pixvis) ~= 0 or fovoverride ~= 0) or (dst < radius * 1.25)) and 
+				ent ~= pac.LocalPlayer and
+				(
+					((util_PixelVisible(ent:EyePos(), radius, ent.pac_pixvis) ~= 0 or fovoverride ~= 0) or (dst < radius * 1.25)) and
 					(
 						(sv_draw_dist ~= 0 and (sv_draw_dist == -1 or dst < sv_draw_dist)) or
 						(ent.pac_draw_distance and (ent.pac_draw_distance <= 0 or ent.pac_draw_distance < dst)) or
 						(dst < draw_dist)
 					)
 				)
-			then 
+			then
 				ent.pac_model = ent:GetModel() -- used for cached functions
-					
+
 				show_parts(ent)
-				
+
 				pac.RenderOverride(ent, "opaque")
 			else
 				hide_parts(ent)
 			end
-		else	
+		else
 			pac.drawn_entities[key] = nil
 		end
 	end
@@ -500,20 +505,20 @@ function pac.PostDrawTranslucentRenderables(drawing_depth,drawing_skybox)
 end
 pac.AddHook("PostDrawTranslucentRenderables")
 
-function pac.Think()	
+function pac.Think()
 	for key, ent in pairs(pac.drawn_entities) do
 		if ent:IsValid() then
 			if ent.pac_drawing and ent:IsPlayer() then
-			
+
 				ent.pac_traceres = util.QuickTrace(ent:EyePos(), ent:GetAimVector()*32000, {ent, ent:GetVehicle(), ent:GetOwner()})
 				ent.pac_hitpos = ent.pac_traceres.HitPos
-				
+
 			end
 		else
 			pac.drawn_entities[key] = nil
 		end
 	end
-	
+
 	if pac.next_frame_funcs then
 		for k, v in pairs(pac.next_frame_funcs) do
 			v()

--- a/lua/pac3/core/client/integration_tools.lua
+++ b/lua/pac3/core/client/integration_tools.lua
@@ -2,7 +2,7 @@ do
 	local draw_localplayer = nil
 
 	function pac.DrawEntity2D(ent, x, y, w, h, cam_pos, cam_ang, cam_fov, cam_nearz, cam_farz)
-		
+
 		if draw_localplayer == nil then
 			hook.Add("ShouldDrawLocalPlayer", "pac_draw_2d_entity", function()
 				if draw_localplayer == true then
@@ -10,7 +10,7 @@ do
 				end
 			end)
 		end
-		
+
 		ent = ent or LocalPlayer()
 		x = x or 0
 		y = y or 0
@@ -23,27 +23,29 @@ do
 		cam.Start2D()
 			cam.Start3D(cam_pos, cam_ang, cam_fov, x, y, w, h, cam_nearz or 5, cam_farz or 4096)
 				cam.IgnoreZ(true)
-					pac.ForceRendering(true)						
+					pac.FlashlightDisable(true)
+					pac.ForceRendering(true)
 						draw_localplayer = true
-						
+
 							pac.RenderOverride(ent, "opaque")
 							pac.RenderOverride(ent, "translucent", true)
-							ent:DrawModel() 
+							ent:DrawModel()
 
-						draw_localplayer = false				
+						draw_localplayer = false
 					pac.ForceRendering(false)
+					pac.FlashlightDisable(false)
 				cam.IgnoreZ(false)
 			cam.End3D()
 		cam.End2D()
 	end
-end 
+end
 
-function pac.SetupENT(ENT, owner)	
+function pac.SetupENT(ENT, owner)
 	ENT.pac_owner = ENT.pac_owner or owner or "self"
-	
+
 	local function find(parent, name)
 		for key, part in pairs(parent:GetChildren()) do
-		
+
 			if part:GetName():lower():find(name) then
 				return part
 			end
@@ -54,9 +56,9 @@ function pac.SetupENT(ENT, owner)
 	end
 
 	function ENT:FindPACPart(outfit, name)
-	
-		name = name:lower() 
-	
+
+		name = name:lower()
+
 		if not outfit.self then
 			for key, val in pairs(outfit) do
 				local part = self:FindPACPart(val, name)
@@ -64,10 +66,10 @@ function pac.SetupENT(ENT, owner)
 					return part
 				end
 			end
-			
+
 			return pac.NULL
 		end
-			
+
 		self.pac_part_find_cache = self.pac_part_find_cache or {}
 
 		local part = self.pac_outfits[outfit.self.UniqueID] or pac.NULL
@@ -76,42 +78,42 @@ function pac.SetupENT(ENT, owner)
 			local cached = self.pac_part_find_cache[name] or pac.NULL
 
 			if cached:IsValid() then return cached end
-			
+
 			part = find(part, name)
-			
-			
+
+
 			if part then
 				self.pac_part_find_cache[name] = part
 
 				return part
 			end
 		end
-		
+
 		return pac.NULL
 	end
 
 	function ENT:AttachPACPart(outfit, owner, keep_uniqueid)
-	
-		if not outfit.self then 
+
+		if not outfit.self then
 			return self:AttachPACSession(outfit, owner)
 		end
-				
-		if outfit.self.OwnerName == "viewmodel" and self:IsWeapon() and self.Owner:IsValid() and self.Owner:IsPlayer() and self.Owner ~= LocalPlayer() then 
+
+		if outfit.self.OwnerName == "viewmodel" and self:IsWeapon() and self.Owner:IsValid() and self.Owner:IsPlayer() and self.Owner ~= LocalPlayer() then
 			return
 		end
-	
+
 		if not keep_uniqueid then
 			outfit = pac.GenerateNewUniqueID(outfit, self:EntIndex())
 		end
-	
+
 		owner = owner or self.pac_owner or self.Owner
-				
+
 		if self.pac_owner == "self" then
 			owner = self
 		elseif self[self.pac_owner] then
 			owner = self[self.pac_owner]
 		end
-		
+
 		self.pac_outfits = self.pac_outfits or {}
 
 		local part = self.pac_outfits[outfit.self.UniqueID] or pac.NULL
@@ -119,14 +121,14 @@ function pac.SetupENT(ENT, owner)
 		if part:IsValid() then
 			part:Remove()
 		end
-	
+
 		part = pac.CreatePart(outfit.self.ClassName, owner)
 		part:SetTable(outfit, true)
-		
+
 		self.pac_outfits[outfit.self.UniqueID] = part
 
 		self.pac_part_find_cache = {}
-		
+
 		if self.pac_show_in_editor == nil then
 			self:SetShowPACPartsInEditor(false)
 			self.pac_show_in_editor = nil
@@ -134,14 +136,14 @@ function pac.SetupENT(ENT, owner)
 	end
 
 	function ENT:RemovePACPart(outfit, keep_uniqueid)
-		if not outfit.self then 
+		if not outfit.self then
 			return self:RemovePACSession(outfit)
 		end
-					
+
 		if not keep_uniqueid then
 			outfit = pac.GenerateNewUniqueID(outfit, self:EntIndex())
 		end
-	
+
 		self.pac_outfits = self.pac_outfits or {}
 
 		local part = self.pac_outfits[outfit.self.UniqueID] or pac.NULL
@@ -152,7 +154,7 @@ function pac.SetupENT(ENT, owner)
 
 		self.pac_part_find_cache = {}
 	end
-		
+
 	function ENT:GetPACPartPosAng(outfit, name)
 		local part = self:FindPACPart(outfit, name)
 
@@ -160,58 +162,58 @@ function pac.SetupENT(ENT, owner)
 			return part.cached_pos, part.cached_ang
 		end
 	end
-	
+
 	function ENT:AttachPACSession(session)
 		for _, part in pairs(session) do
 			self:AttachPACPart(part)
 		end
 	end
-	
+
 	function ENT:RemovePACSession(session)
 		for _, part in pairs(session) do
 			self:RemovePACPart(part)
 		end
 	end
-	
+
 	function ENT:SetPACDrawDistance(dist)
 		self.pac_draw_distance = dist
 	end
-	
+
 	function ENT:GetPACDrawDistance()
 		return self.pac_draw_distance
 	end
-		
+
 	function ENT:SetShowPACPartsInEditor(b)
 		self.pac_outfits = self.pac_outfits or {}
-		
+
 		for key, part in pairs(self.pac_outfits) do
 			part.show_in_editor = b
 		end
-		
+
 		self.pac_show_in_editor = b
 	end
-	
+
 	function ENT:GetShowPACPartsInEditor()
 		return self.pac_show_in_editor
 	end
 end
 
 function pac.SetupSWEP(SWEP, owner)
-	SWEP.pac_owner = owner or "Owner"	
-	pac.SetupENT(SWEP, owner)	
+	SWEP.pac_owner = owner or "Owner"
+	pac.SetupENT(SWEP, owner)
 end
 
 function pac.AddEntityClassListener(class, session, check_func, draw_dist)
-	
+
 	if session.self then
 		session = {session}
 	end
-	
+
 	draw_dist = 0
 	check_func = check_func or function(ent) return ent:GetClass() == class end
-	
+
 	local id = "pac_auto_attach_" .. class
-	
+
 	local weapons = {}
 	local function weapon_think()
 		for _, ent in pairs(weapons) do
@@ -220,13 +222,13 @@ function pac.AddEntityClassListener(class, session, check_func, draw_dist)
 					if not ent.AttachPACSession then
 						pac.SetupSWEP(ent)
 					end
-				
+
 					if ent.Owner:GetActiveWeapon() == ent then
 						if not ent.pac_deployed then
 							ent:AttachPACSession(session)
-							ent.pac_deployed = true			
+							ent.pac_deployed = true
 						end
-						
+
 						ent.pac_last_owner = ent.Owner
 					else
 						if ent.pac_deployed then
@@ -243,7 +245,7 @@ function pac.AddEntityClassListener(class, session, check_func, draw_dist)
 			end
 		end
 	end
-	
+
 	local function created(ent)
 		if ent:IsValid() and check_func(ent) then
 			if ent:IsWeapon() then
@@ -256,18 +258,18 @@ function pac.AddEntityClassListener(class, session, check_func, draw_dist)
 			end
 		end
 	end
-	
+
 	local function removed(ent)
 		if ent:IsValid() and check_func(ent) and ent.pac_outfits then
 			ent:RemovePACSession(session)
 			weapons[ent:EntIndex()] = nil
 		end
 	end
-	
+
 	for key, ent in pairs(ents.GetAll()) do
 		created(ent)
 	end
-	
+
 	hook.Add("EntityRemoved", id, removed)
 	hook.Add("OnEntityCreated", id, created)
 end
@@ -276,17 +278,17 @@ function pac.RemoveEntityClassListener(class, session, check_func)
 	if session.self then
 		session = {session}
 	end
-	
+
 	check_func = check_func or function(ent) return ent:GetClass() == class end
-	
+
 	for key, ent in pairs(ents.GetAll()) do
 		if check_func(ent) and ent.pac_outfits then
 			ent:RemovePACSession(session)
 		end
 	end
-	
+
 	local id = "pac_auto_attach_" .. class
-		
+
 	hook.Remove("Think", id)
 	hook.Remove("EntityRemoved", id)
 	hook.Remove("OnEntityCreated", id)
@@ -298,8 +300,8 @@ timer.Simple(0, function()
 			if b == nil then
 				b = true
 			end
-			
-			luadev.RunOnClients(("pac.%s(%q, {%s})"):format(b and "AddEntityClassListener" or "RemoveEntityClassListener", class_name, file.Read("pac3/".. name .. ".txt", "DATA"))) 
+
+			luadev.RunOnClients(("pac.%s(%q, {%s})"):format(b and "AddEntityClassListener" or "RemoveEntityClassListener", class_name, file.Read("pac3/".. name .. ".txt", "DATA")))
 		end
 	end
 end)

--- a/lua/pac3/core/client/parts/model.lua
+++ b/lua/pac3/core/client/parts/model.lua
@@ -24,8 +24,8 @@ local render_MaterialOverride       = render.ModelMaterialOverride
 local render_PopFilterMag           = render.PopFilterMag
 local render_PopFilterMin           = render.PopFilterMin
 local render_PopFlashlightMode      = render.PopFlashlightMode
-local render_PushFilterMag          = render.PushFilterMag 
-local render_PushFilterMin          = render.PushFilterMin 
+local render_PushFilterMag          = render.PushFilterMag
+local render_PushFilterMin          = render.PushFilterMin
 local render_PushFlashlightMode     = render.PushFlashlightMode
 local render_SuppressEngineLighting = render.SuppressEngineLighting
 
@@ -39,7 +39,7 @@ local EF_BONEMERGE                  = EF_BONEMERGE
 local MATERIAL_CULLMODE_CW          = MATERIAL_CULLMODE_CW
 local MATERIAL_CULLMODE_CCW         = MATERIAL_CULLMODE_CCW
 
-local PART = {} 
+local PART = {}
 
 PART.ClassName = "model"
 PART.ManualDraw = true
@@ -71,21 +71,21 @@ pac.StartStorableVars()
 	pac.GetSet(PART, "ModelFallback", "")
 	pac.GetSet(PART, "OwnerEntity", false)
 	pac.GetSet(PART, "TextureFilter", 3)
-	
+
 	pac.GetSet(PART, "BlurLength", 0)
 	pac.GetSet(PART, "BlurSpacing", 0)
-	
+
 	pac.GetSet(PART, "UseLegacyScale", false)
-	
+
 	pac.GetSet(PART, "UsePlayerColor", false)
 	pac.GetSet(PART, "UseWeaponColor", false)
-	
+
 	pac.GetSet(PART, "LodOverride", -1)
 pac.EndStorableVars()
 
 function PART:GetNiceName()
 	local str = pac.PrettifyName(("/".. self:GetModel()):match(".+/(.-)%."))
-	
+
 	return str and str:gsub("%d", "") or "error"
 end
 
@@ -94,8 +94,8 @@ function PART:Reset()
 	for _, key in pairs(self:GetStorableVars()) do
 		if key ~= "Model" and key ~= "OwnerEntity" then
 			local var = self[key] and self["Get"..key](self) or self[key], key
-			var = pac.class.Copy(var) or var	
-			
+			var = pac.class.Copy(var) or var
+
 			self["Set" .. key](self, var)
 		end
 	end
@@ -110,7 +110,7 @@ end
 
 function PART:SetTextureFilter(num)
 	self.TextureFilter = num
-	
+
 	self.texfilter_enum = math.Clamp(math.Round(num), 0, 3)
 end
 
@@ -131,18 +131,18 @@ end
 function PART:OnShow()
 	local owner = self:GetOwner()
 	local ent = self:GetEntity()
-	
+
 	if ent:IsValid() and owner:IsValid() and owner ~= ent then
 		ent:SetPos(owner:EyePos())
 		--ent:SetParent(owner)
 		--ent:SetOwner(owner)
 		self.BoneIndex = nil
-		
+
 		if self.OwnerEntity then
 			self:SetOwnerEntity(self.OwnerEntity)
 		end
 	end
-	
+
 	if self.BlurLength > 0 then
 		self.blur_history = {}
 		self.blur_last_add = 0
@@ -151,10 +151,10 @@ end
 
 function PART:OnThink()
 	pac.SetModelScale(self:GetEntity(), self.Scale * self.Size, nil, self.UseLegacyScale)
-	
+
 	self:CheckScale()
 	self:CheckBoneMerge()
-	
+
 	local ent = self:GetEntity()
 	if ent:IsValid() then
 		ent.pac_matproxies = ent.pac_matproxies or {}
@@ -164,15 +164,15 @@ end
 
 function PART:SetOwnerEntity(b)
 	self.OwnerEntity = b
-	
+
 	local ent = self:GetOwner()
 	if ent:IsValid() then
 		if b then
 			self.Entity = ent
-			
+
 			function ent.RenderOverride(ent)
 				if self:IsValid() then
-					if not self.HideEntity then 
+					if not self.HideEntity then
 						self:PreEntityDraw(ent, ent, ent:GetPos(), ent:GetAngles())
 						ent:DrawModel()
 						self:PostEntityDraw(ent, ent, ent:GetPos(), ent:GetAngles())
@@ -183,7 +183,7 @@ function PART:SetOwnerEntity(b)
 			end
 		else
 			self.Entity = NULL
-			
+
 			ent.RenderOverride = nil
 			pac.SetModelScale(ent, Vector(1,1,1), nil, self.UseLegacyScale)
 		end
@@ -200,22 +200,22 @@ function PART:PreEntityDraw(owner, ent, pos, ang)
 			self.cached_ang = ang
 		end
 	end
-	
+
 	if self.Alpha ~= 0 and self.Size ~= 0 then
 		self:ModifiersPreEvent("OnDraw")
-	
+
 		if not pac.DisableDoubleFace then
 			if self.DoubleFace or self.Invert then
 				render_CullMode(MATERIAL_CULLMODE_CW)
 			end
 		end
-		
+
 		if not pac.DisableColoring then
-			if not self.Colorf then 
+			if not self.Colorf then
 				self:SetColor(self:GetColor())
 			end
-		
-			if self.UseWeaponColor or self.UsePlayerColor then 
+
+			if self.UseWeaponColor or self.UsePlayerColor then
 				local owner = self:GetOwner(true)
 				if owner:IsPlayer() then
 					local c = owner:GetPlayerColor()
@@ -230,16 +230,16 @@ function PART:PreEntityDraw(owner, ent, pos, ang)
 					end
 				end
 			end
-			
+
 			-- Save existing material color and alpha
 			if self.Materialm then
 				-- this is so bad for GC performance
 				self.OriginalMaterialColor = self.OriginalMaterialColor or IMaterial_GetVector (self.Materialm, "$color")
 				self.OriginalMaterialAlpha = self.OriginalMaterialAlpha or IMaterial_GetFloat  (self.Materialm, "$alpha")
 			end
-			
+
 			local r, g, b = self.Colorf.r, self.Colorf.g, self.Colorf.b
-			
+
 			if self.LightBlend ~= 1 then
 				-- what the fucking fuck is this lighting code
 				-- it doesn't even look physically correct
@@ -247,20 +247,20 @@ function PART:PreEntityDraw(owner, ent, pos, ang)
 				r = r * v.r * self.LightBlend
 				g = g * v.g * self.LightBlend
 				b = b * v.b * self.LightBlend
-				
+
 				v = render.GetAmbientLightColor(pos)
 				r = r * v.r * self.LightBlend
 				g = g * v.g * self.LightBlend
 				b = b * v.b * self.LightBlend
 			end
-			
+
 			-- render.SetColorModulation and render.SetAlpha set the material $color and $alpha.
-			render_SetColorModulation(r,g,b) 
+			render_SetColorModulation(r,g,b)
 			render_SetBlend(self.Alpha)
 		end
-		
+
 		if self.Fullbright then
-			render_SuppressEngineLighting(true) 
+			render_SuppressEngineLighting(true)
 		end
 	end
 end
@@ -277,15 +277,15 @@ function PART:PostEntityDraw(owner, ent, pos, ang)
 				render_CullMode(MATERIAL_CULLMODE_CCW)
 			end
 		end
-			
+
 		if self.Fullbright then
-			render_SuppressEngineLighting(false) 
+			render_SuppressEngineLighting(false)
 		end
-		
-		if self.CellShade > 0 then		
+
+		if self.CellShade > 0 then
 			self:CheckScale()
 			self:CheckBoneMerge()
-		
+
 			pac.SetModelScale(ent, self.Scale * self.Size * (1 + self.CellShade), nil, self.UseLegacyScale)
 				render_CullMode(MATERIAL_CULLMODE_CW)
 					render_SetColorModulation(0,0,0)
@@ -297,7 +297,7 @@ function PART:PostEntityDraw(owner, ent, pos, ang)
 				render_CullMode(MATERIAL_CULLMODE_CCW)
 			pac.SetModelScale(ent, self.Scale * self.Size, nil, self.UseLegacyScale)
 		end
-		
+
 		-- Restore material color and alpha
 		if self.Materialm then
 			IMaterial_SetVector (self.Materialm, "$color", self.OriginalMaterialColor or DEFAULT_COLOR)
@@ -305,15 +305,15 @@ function PART:PostEntityDraw(owner, ent, pos, ang)
 			self.OriginalMaterialColor = nil
 			self.OriginalMaterialAlpha = nil
 		end
-		
+
 		self:ModifiersPostEvent("OnDraw")
 	end
 end
 
 function PART:OnDraw(owner, pos, ang)
 	local ent = self:GetEntity()
-	
-	if not ent:IsValid() then 
+
+	if not ent:IsValid() then
 		self:Reset()
 		ent = self:GetEntity()
 		if not ent:IsValid() then
@@ -321,24 +321,24 @@ function PART:OnDraw(owner, pos, ang)
 			return
 		end
 	end
-	
+
 	self:PreEntityDraw(owner, ent, pos, ang)
-		self:DrawModel(ent, pos, ang)	
+		self:DrawModel(ent, pos, ang)
 	self:PostEntityDraw(owner, ent, pos, ang)
-	
+
 	pac.ResetBones(ent)
-			
+
 	if self.OriginFix then
 		self:SetPositionOffset(self:GetPositionOffset() + -ent:OBBCenter() * self.Scale * self.Size)
 		self:SetOriginFix(false)
 	end
-	
+
 	if ent.pac_can_legacy_scale ~= false then
 		ent.pac_can_legacy_scale = not not ent.pac_can_legacy_scale
 	end
 end
 
-surface.CreateFont("pac_urlobj_loading", 
+surface.CreateFont("pac_urlobj_loading",
 	{
 		font      = "Arial",
 		size      = 20,
@@ -349,22 +349,22 @@ surface.CreateFont("pac_urlobj_loading",
 )
 
 -- ugh lol
-local function RealDrawModel(self, ent, pos, ang) 
+local function RealDrawModel(self, ent, pos, ang)
 	if self.Mesh then
 		ent:SetModelScale(0,0)
 		ent:DrawModel()
-		
+
 		local matrix = Matrix()
-		
+
 		matrix:SetAngles(ang)
 		matrix:SetTranslation(pos)
-		
+
 		if ent.pac_model_scale then
 			matrix:Scale(ent.pac_model_scale)
 		else
 			matrix:Scale(self.Scale * self.Size)
 		end
-						
+
 		cam_PushModelMatrix(matrix)
 			self.Mesh:Draw()
 		cam_PopModelMatrix()
@@ -378,41 +378,45 @@ function PART:DrawModel(ent, pos, ang)
 		if self.loading_obj then
 			self:DrawLoadingText(ent, pos, ang)
 		end
-		
+
 		if self.loading_obj and not self.Mesh then return end
-		
+
 		local textureFilter = self.texfilter_enum or TEXFILTER.ANISOTROPIC
 		if textureFilter ~= TEXFILTER.ANISOTROPIC or self.Mesh then
 			render_PushFilterMin(textureFilter)
 			render_PushFilterMag(textureFilter)
 		end
-		
-		render_MaterialOverride(self.Materialm) 
-		render_ModelMaterialOverride(self.Materialm) 
-		if self.Materialm then 
-			render_SetMaterial(self.Materialm) 
+
+		render_MaterialOverride(self.Materialm)
+		render_ModelMaterialOverride(self.Materialm)
+		if self.Materialm then
+			render_SetMaterial(self.Materialm)
 		end
-		
+
 		-- Render model
 		local passCount = math_max (1, self.Passes)
 		if self.Alpha >= 1 then
 			passCount = math_min (passCount, 1)
 		end
-		
+
 		for i = 1, passCount do
 			RealDrawModel(self, ent, pos, ang)
 		end
-		
+
 		-- Flashlight(?)
-		render_PushFlashlightMode(true)
+		if not pac.flashlight_disabled then
+			render_PushFlashlightMode(true)
+		end
 			RealDrawModel(self, ent, pos, ang)
-		render_PopFlashlightMode()
-		
+		if not pac.flashlight_disabled then
+			render_PopFlashlightMode()
+		end
+
 		if textureFilter ~= TEXFILTER.ANISOTROPIC or self.Mesh then
 			render_PopFilterMag()
 			render_PopFilterMin()
 		end
-		
+
 		-- Render "blur"
 		if self.BlurLength > 0 then
 			self:DrawBlur(ent, pos, ang)
@@ -424,13 +428,13 @@ function PART:DrawLoadingText(ent, pos, ang)
 	cam.Start2D()
 	cam.IgnoreZ(true)
 		local pos2d = pos:ToScreen()
-	
+
 		surface.SetFont("pac_urlobj_loading")
 		surface.SetTextColor(255, 255, 255, 255)
-		
+
 		local str = self.loading_obj .. string.rep(".", pac.RealTime * 3 % 3)
 		local w, h = surface.GetTextSize(self.loading_obj .. "...")
-		
+
 		surface.SetTextPos(pos2d.x - w/2, pos2d.y - h/2)
 		surface.DrawText(str)
 	cam.IgnoreZ(false)
@@ -439,37 +443,37 @@ end
 
 function PART:DrawBlur(ent, pos, ang)
 	self.blur_history = self.blur_history or {}
-	
+
 	local blurSpacing = self.BlurSpacing
-	
+
 	if not self.blur_last_add or blurSpacing == 0 or self.blur_last_add < pac.RealTime then
 		table_insert(self.blur_history, {pos, ang})
 		self.blur_last_add = pac.RealTime + blurSpacing / 1000
 	end
-	
+
 	local blurHistoryLength = #self.blur_history
 	for i = 1, blurHistoryLength do
 		local pos, ang = self.blur_history[i][1], self.blur_history[i][2]
-		
+
 		render_SetBlend(self.Alpha * (i / blurHistoryLength))
-		
+
 		ent:SetPos(pos)
 		ent:SetAngles(ang)
 		ent:SetupBones()
-		
+
 		RealDrawModel(self, ent, pos, ang)
 	end
 
 	local maximumBlurHistoryLength = math.min(self.BlurLength, 20)
 	while #self.blur_history >= maximumBlurHistoryLength do
-		table_remove(self.blur_history, 1) 
+		table_remove(self.blur_history, 1)
 	end
 end
 
-local function set_mesh(part, mesh)		
+local function set_mesh(part, mesh)
 	part.Mesh = mesh
 	part.Entity.pac_bones = nil
-	
+
 	if not part.Materialm then
 		part.Materialm = Material("error")
 	end
@@ -479,9 +483,9 @@ local function set_mesh(part, mesh)
 		part:DrawModel(ent, ent:GetPos(), ent:GetAngles())
 		part:ModifiersPostEvent("OnDraw")
 	end
-	
+
 	-- temp
-	part.Entity:SetRenderBounds(Vector(1, 1, 1)*-300, Vector(1, 1, 1)*300)	
+	part.Entity:SetRenderBounds(Vector(1, 1, 1)*-300, Vector(1, 1, 1)*300)
 end
 
 function PART:SetModel(modelPath)
@@ -489,25 +493,25 @@ function PART:SetModel(modelPath)
 
 	if modelPath and modelPath:find("http") and pac.urlobj then
 		self.loading_obj = "downloading"
-		
+
 		if not self.is_obj then
 			self:Initialize(true)
 		end
-		
+
 		pac.urlobj.GetObjFromURL(modelPath, false, false,
 			function(meshes, err)
 				if not self:IsValid() then return end
-				
+
 				self.loading_obj = false
-				
+
 				self.Entity = self:GetEntity()
-				
+
 				if not meshes and err then
 					self.Entity:SetModel("error.mdl")
 					self.Mesh = nil
 					return
 				end
-				
+
 				if table.Count(meshes) == 1 then
 					set_mesh(self, select(2, next(meshes)))
 				else
@@ -518,11 +522,11 @@ function PART:SetModel(modelPath)
 						part:SetMaterial(self:GetMaterial())
 						set_mesh(part, mesh)
 					end
-					
+
 					self:SetAlpha(0)
 				end
 			end,
-			function(finished, statusMessage) 
+			function(finished, statusMessage)
 				if finished then
 					self.loading_obj = nil
 				else
@@ -530,17 +534,17 @@ function PART:SetModel(modelPath)
 				end
 			end
 		)
-		
+
 		self.Model = modelPath
 		return
 	end
-	
+
 	if self.is_obj or not self.Entity:IsValid() then
 		self:Initialize(false)
 	end
-	
+
 	self.Mesh = nil
-	
+
 	local real_model = modelPath
 	local ret,ret2 = hook.Run("pac_model:SetModel", self, modelPath, self.ModelFallback)
 	if ret == nil then
@@ -550,7 +554,7 @@ function PART:SetModel(modelPath)
 		real_model = modelPath
 		real_model = pac.FilterInvalidModel(real_model,self.ModelFallback)
 	end
-	
+
 	self.Model = modelPath
 	self.Entity.pac_bones = nil
 	self.Entity:SetModel(real_model)
@@ -567,7 +571,7 @@ function PART:CheckScale()
 			end
 			return true
 		end
-		
+
 		self.requires_bone_model_scale = false
 	end
 end
@@ -581,8 +585,8 @@ function PART:SetScale(var)
 	var = var or Vector(1,1,1)
 
 	self.Scale = var
-		
-	if self.AlternativeScaling then	
+
+	if self.AlternativeScaling then
 		if not self:CheckScale() then
 			pac.SetModelScale(self.Entity, self.Scale, nil, self.UseLegacyScale)
 			self.used_alt_scale = true
@@ -600,10 +604,10 @@ end
 
 function PART:SetSize(var)
 	var = var or 1
-	
+
 	self.Size = var
-	
-	if self.AlternativeScaling then	
+
+	if self.AlternativeScaling then
 		pac.SetModelScale(self.Entity, nil, self.Size, self.UseLegacyScale)
 		self.used_alt_scale = true
 	else
@@ -618,14 +622,14 @@ function PART:SetSize(var)
 end
 
 function PART:SetBrightness(num)
-	self.Brightness = num	
+	self.Brightness = num
 	self:SetColor(self:GetColor())
 end
 
 function PART:SetColor(var)
 	self.Color = var
 	local owner = self:GetPlayerOwner()
-	
+
 	if self.UsePlayerColor and owner:IsValid() then
 		local c = owner:GetPlayerColor() * self.Brightness
 		self.Colorf = Color(c.r, c.g, c.b)
@@ -649,39 +653,39 @@ end
 
 function PART:FixMaterial()
 	local mat = self.Materialm
-	
+
 	if not mat then return end
-	
+
 	local shader = mat:GetShader()
-	
+
 	if shader == "UnlitGeneric" then
 		local tex_path = mat:GetString("$basetexture")
-		
-		if tex_path then		
+
+		if tex_path then
 			local params = {}
-			
+
 			params["$basetexture"] = tex_path
 			params["$vertexcolor"] = 1
 			params["$additive"] = 1
-			
+
 			self.Materialm = CreateMaterial("pac_fixmat_" .. os.clock(), "VertexLitGeneric", params)
-		end		
+		end
 	end
 end
 
 function PART:SetMaterial(var)
 	var = var or ""
-	
+
 	if not pac.Handleurltex(self, var) then
 		if var == "" then
 			self.Materialm = nil
-		else			
+		else
 			self.Materialm = pac.Material(var, self)
 			self:FixMaterial()
 			self:CallEvent("material_changed")
 		end
 	end
-		
+
 	self.Material = var
 end
 
@@ -689,22 +693,22 @@ function PART:SetBodygroupState(var)
 	var = var or 0
 
 	self.BodygroupState = var
-	timer.Simple(0, function() 
+	timer.Simple(0, function()
 		if self:IsValid() and self.Entity:IsValid() then
-			self.Entity:SetBodygroup(self.Bodygroup, var) 
+			self.Entity:SetBodygroup(self.Bodygroup, var)
 		end
-	end)		
+	end)
 end
 
 function PART:SetBodygroup(var)
 	var = var or 0
 
 	self.Bodygroup = var
-	timer.Simple(0, function() 
+	timer.Simple(0, function()
 		if self:IsValid() and self.Entity:IsValid() then
-			self.Entity:SetBodygroup(var, self.BodygroupState) 
+			self.Entity:SetBodygroup(var, self.BodygroupState)
 		end
-	end)		
+	end)
 end
 
 function PART:SetSkin(var)
@@ -716,24 +720,24 @@ end
 
 function PART:OnRemove()
 	if not self.OwnerEntity then
-		timer.Simple(0, function() 
+		timer.Simple(0, function()
 			SafeRemoveEntity(self.Entity)
 		end)
 	end
 end
 
 function PART:SetBoneMergeAlternative(b)
-	
+
 	self.BoneMergeAlternative = b
 
 	local ent = self.Entity
 	if ent:IsValid() then
 		ent.pac_bones = nil
 		local owner = self:GetOwner()
-		if owner:IsValid() then 
+		if owner:IsValid() then
 			owner.pac_bones = nil
 		end
-		
+
 		if b then
 			ent:SetParent(owner)
 		else
@@ -752,13 +756,13 @@ end
 
 function PART:CheckBoneMerge()
 	local ent = self.Entity
-	
+
 	if self.skip_orient then return end
-	
-	if ent:IsValid() and not ent:IsPlayer() then			
+
+	if ent:IsValid() and not ent:IsPlayer() then
 		if self.BoneMerge and not self.BoneMergeAlternative then
 			local owner = self:GetOwner()
-			if ent:GetParent() ~= owner then	
+			if ent:GetParent() ~= owner then
 				ent:SetParent(owner)
 
 				if not ent:IsEffectActive(EF_BONEMERGE) then
@@ -766,27 +770,27 @@ function PART:CheckBoneMerge()
 				end
 			end
 		else
-			if ent:GetParent():IsValid() then	
+			if ent:GetParent():IsValid() then
 				ent:SetParent(NULL)
 
 				if ent:IsEffectActive(EF_BONEMERGE) then
 					ent:RemoveEffects(EF_BONEMERGE)
 				end
-				
+
 				self.requires_bone_model_scale = false
 			end
 		end
 	end
 end
 
-local bad_bones = 
+local bad_bones =
 {
 	["ValveBiped.Bip01_L_Finger0"] = true,
 	["ValveBiped.Bip01_L_Finger01"] = true,
-	["ValveBiped.Bip01_L_Finger02"] = true, 
+	["ValveBiped.Bip01_L_Finger02"] = true,
 
 	["ValveBiped.Bip01_L_Finger1"] = true,
-	["ValveBiped.Bip01_L_Finger11"] = true, 
+	["ValveBiped.Bip01_L_Finger11"] = true,
 	["ValveBiped.Bip01_L_Finger12"] = true,
 
 	["ValveBiped.Bip01_L_Finger2"] = true,
@@ -813,19 +817,19 @@ function PART:OnBuildBonePositions()
 
 	local ent = self:GetEntity()
 	local owner = self:GetOwner()
-	
+
 	if not ent:IsValid() or not owner:IsValid() or not ent:GetBoneCount() or ent:GetBoneCount() < 1 then return end
-	
+
 	if self.OverallSize ~= 1 then
 		for i = 0, ent:GetBoneCount()-1 do
 			ent:ManipulateBoneScale(i, ent:GetManipulateBoneScale(i) * SCALE_NORMAL * self.OverallSize)
 		end
 	end
-	
-	if self.requires_bone_model_scale then		
+
+	if self.requires_bone_model_scale then
 		local scale = self.Scale * self.Size
-		
-		for i = 0, ent:GetBoneCount()-1 do	
+
+		for i = 0, ent:GetBoneCount()-1 do
 			if i == 0 then
 				ent:ManipulateBoneScale(i, ent:GetManipulateBoneScale(i) * Vector(scale.x ^ 0.25, scale.y ^ 0.25, scale.z ^ 0.25))
 			else


### PR DESCRIPTION
In 2D contexts such as Derma Panels using Pop/PushFlashlightMode leads to crashes, this fixes these crashes. 

Please ignore the whitespace in the diffs, my editor removes tabs and whitespace on empty lines. 