### PR TITLE
xpcall in wear timer

### DIFF
--- a/lua/pac3/editor/server/wear.lua
+++ b/lua/pac3/editor/server/wear.lua
@@ -2,10 +2,16 @@ pace.StreamQueue = pace.StreamQueue or {}
 
 local frame_number = 0
 
+local function catchError(err)
+	print('[PAC3] Error: ', err)
+	print(debug.traceback())
+end
+
 timer.Create("pac_check_stream_queue", 0.1, 0, function()
 	if not pace.BusyStreaming and #pace.StreamQueue ~= 0 then
-		pace.SubmitPart(unpack(table.remove(pace.StreamQueue)))
+		xpcall(pace.SubmitPart, catchError, unpack(table.remove(pace.StreamQueue)))
 	end
+	
 	frame_number = frame_number + 1
 end)
 


### PR DESCRIPTION
So, any attempt from players to break wear on server will fail
This fixes the case where player is trying to send very big outfit that
crashes wear on serverside