### PR TITLE
Menu improvements

### DIFF
--- a/lua/pac3/editor/client/config.lua
+++ b/lua/pac3/editor/client/config.lua
@@ -269,6 +269,7 @@ pace.MiscIcons = {
 	appearance = "icon16/paintcan.png",
 	orientation = "icon16/shape_handles.png",
 	chat = "icon16/comment.png",
+	replace = "icon16/arrow_refresh.png",
 }
 pace.PartIcons =
 {

--- a/lua/pac3/editor/client/panels/editor.lua
+++ b/lua/pac3/editor/client/panels/editor.lua
@@ -6,13 +6,17 @@ PANEL.ClassName = "editor"
 PANEL.Base = "DFrame"
 PANEL.menu_bar = NULL
 
+PANEL.pac3_PanelsToRemove = {
+	'btnClose', 'btnMaxim', 'btnMinim'
+}
+
 local BAR_SIZE = 17
 local RENDERSCORE_SIZE = 13
 
 local use_tabs = CreateClientConVar("pac_property_tabs", 1, true)
 
 function PANEL:Init()
-	self:SetTitle("pac3 " .. L"editor")
+	self:SetTitle("")
 	self:SetSizable(true)
 	--self:DockPadding(2, 23, 2, 2)
 
@@ -112,6 +116,12 @@ local auto_size = CreateClientConVar("pac_auto_size_properties", 1, true)
 
 function PANEL:PerformLayout()
 	DFrame.PerformLayout(self)
+
+	for i, val in pairs(self.pac3_PanelsToRemove) do
+		if IsValid(self[val]) then
+			self[val].SetSize(self[val], 0, 0) -- Hacky
+		end
+	end
 
 	self.div:InvalidateLayout()
 	self.bottom:PerformLayout()

--- a/lua/pac3/editor/client/parts.lua
+++ b/lua/pac3/editor/client/parts.lua
@@ -240,23 +240,31 @@ do -- menu
 		end
 
 		menu:AddOption(L"copy", function()
-			local tbl = obj:ToTable()
-				tbl.self.Name = nil
-				tbl.self.Description = nil
-				tbl.self.ParentName = nil
-				tbl.self.Parent = nil
-				tbl.self.UniqueID = util.CRC(tbl.self.UniqueID .. tostring(tbl))
-
-				tbl.children = {}
-			pace.Clipboard = tbl
+			pace.Clipboard = obj
 		end):SetImage(pace.MiscIcons.copy)
 
 		menu:AddOption(L"paste", function()
 			if pace.Clipboard then
-				obj:SetTable(pace.Clipboard)
+				local newObj = pace.Clipboard:Clone()
+				newObj:SetParent(obj)
 			end
 			--pace.Clipboard = nil
 		end):SetImage(pace.MiscIcons.paste)
+
+		menu:AddOption(L"paste properties", function()
+			if pace.Clipboard then
+				local tbl = pace.Clipboard:ToTable()
+					tbl.self.Name = nil
+					tbl.self.Description = nil
+					tbl.self.ParentName = nil
+					tbl.self.Parent = nil
+					tbl.self.UniqueID = util.CRC(tbl.self.UniqueID .. tostring(tbl))
+
+					tbl.children = {}
+				obj:SetTable(tbl)
+			end
+			--pace.Clipboard = nil
+		end):SetImage(pace.MiscIcons.replace)
 
 		menu:AddOption(L"clone", function()
 			obj:Clone()

--- a/lua/pac3/editor/client/saved_parts.lua
+++ b/lua/pac3/editor/client/saved_parts.lua
@@ -1,5 +1,14 @@
 local L = pace.LanguageString
 
+-- load only when hovered above
+local function add_expensive_submenu_load(pnl, callback)
+	local old = pnl.OnCursorEntered
+	pnl.OnCursorEntered = function(...)
+		callback()
+		pnl.OnCursorEntered = old
+		return old(...)
+	end
+end
 
 function pace.SaveParts(name, prompt_name, override_part)
 	if not name or prompt_name then
@@ -377,16 +386,21 @@ function pace.AddSavedPartsToMenu(menu, clear, override_part)
 	local backups, pnl = menu:AddSubMenu(L"backups")
 	pnl:SetImage(pace.MiscIcons.clone)
 	backups.GetDeleteSelf = function() return false end
-	local files = file.Find("pac3/__backup/*", "DATA")
-	table.sort(files, function(a, b)
-		return file.Time("pac3/__backup/" .. a, "DATA") > file.Time("pac3/__backup/" .. b, "DATA")
+
+	add_expensive_submenu_load(pnl, function()
+		local files = file.Find("pac3/__backup/*", "DATA")
+
+		table.sort(files, function(a, b)
+			return file.Time("pac3/__backup/" .. a, "DATA") > file.Time("pac3/__backup/" .. b, "DATA")
+		end)
+
+		for _, name in pairs(files) do
+			local full_path = "pac3/__backup/" .. name
+			local friendly_name = os.date("%m/%d/%Y %H:%M:%S ", file.Time(full_path, "DATA")) .. string.NiceSize(file.Size(full_path, "DATA"))
+			backups:AddOption(friendly_name, function() pace.LoadParts("__backup/" .. name, true) end)
+			:SetImage(pace.MiscIcons.outfit)
+		end
 	end)
-	for _, name in pairs(files) do
-		local full_path = "pac3/__backup/" .. name
-		local friendly_name = os.date("%m/%d/%Y %H:%M:%S ", file.Time(full_path, "DATA")) .. string.NiceSize(file.Size(full_path, "DATA"))
-		backups:AddOption(friendly_name, function() pace.LoadParts("__backup/" .. name, true) end)
-		:SetImage(pace.MiscIcons.outfit)
-	end
 
 	menu:AddSpacer()
 

--- a/lua/pac3/editor/client/saved_parts.lua
+++ b/lua/pac3/editor/client/saved_parts.lua
@@ -383,6 +383,13 @@ function pace.AddSavedPartsToMenu(menu, clear, override_part)
 		end
 	end
 
+	menu:AddSpacer()
+
+	local tbl = pace.GetSavedParts()
+	populate_parts(menu, tbl, override_part, clear)
+
+	menu:AddSpacer()
+
 	local backups, pnl = menu:AddSubMenu(L"backups")
 	pnl:SetImage(pace.MiscIcons.clone)
 	backups.GetDeleteSelf = function() return false end
@@ -401,11 +408,6 @@ function pace.AddSavedPartsToMenu(menu, clear, override_part)
 			:SetImage(pace.MiscIcons.outfit)
 		end
 	end)
-
-	menu:AddSpacer()
-
-	local tbl = pace.GetSavedParts()
-	populate_parts(menu, tbl, override_part, clear)
 end
 
 local function populate_parts(menu, tbl, dir, override_part)

--- a/lua/pac3/editor/client/translations/russian.lua
+++ b/lua/pac3/editor/client/translations/russian.lua
@@ -150,4 +150,5 @@ return {
 ["sprite"] = "спрайт",
 ["offset"] = "смещение",
 ["toggle t pose"] = "переключить т-позу",
+["paste properties"] = "вставить свойства",
 }


### PR DESCRIPTION
Make `Copy` works like `Clone`, but with auto parent to selected part
Don't populate `Backups` after `Load` was hovered, and moved `Backups` to bottom of menu
Hide `DFrame` useless panels in PAC3 Editor Panel