### PR TITLE
Preserve entity model after PVS update and reset model when entity part is removed.

### DIFF
--- a/lua/pac3/core/client/hooks.lua
+++ b/lua/pac3/core/client/hooks.lua
@@ -219,6 +219,16 @@ function pac.NotifyShouldTransmit(ent,st)
 			end)
 		end
 	end
+	if ent.pac_model and ent.pac_originalmodel then
+		--This hack is required due to garrysmod resyncing the entity's model when its PVS changes
+		--Timer is required because it seems to depend on how long the engine takes to do its own update, which will override our update.
+		timer.Simple(0.3,function()
+			if ent:IsValid() and ent.pac_originalmodel and ent.pac_model then
+				ent:SetModel(ent.pac_originalmodel)
+				ent:SetModel(ent.pac_model)
+			end
+		end)
+	end
 end
 pac.AddHook("NotifyShouldTransmit")
 

--- a/lua/pac3/core/client/parts/model2.lua
+++ b/lua/pac3/core/client/parts/model2.lua
@@ -596,6 +596,8 @@ do
 	function PART:OnShow()
 		local ent = self:GetEntity()
 
+		ent.pac_originalmodel = ent.pac_originalmodel or ent:GetModel()
+
 		if self.Model == "" then
 			self.Model = ent:GetModel() or ""
 		end
@@ -646,8 +648,18 @@ do
 		if not ent:IsValid() then return end
 
 		ent:SetModel(path)
+		ent.pac_model = path
 
 		self:OnThink()
+	end
+
+	function PART:OnRemove()
+		local ent = self:GetEntity()
+		if not ent:IsValid() then return end
+
+		ent:SetModel(ent.pac_originalmodel)
+		ent.pac_originalmodel = nil
+		ent.pac_model = nil
 	end
 
 	function PART:OnThink()


### PR DESCRIPTION
Probably not the best way.

Is there a part hook for when an entity part's owner is changed? I think that should be used instead of OnShow/OnRemove