### PR TITLE
Translucent parts don't play nicely with blend override.

### DIFF
--- a/lua/pac3/core/client/base_part.lua
+++ b/lua/pac3/core/client/base_part.lua
@@ -975,7 +975,8 @@ do -- drawing. this code is running every frame
 			if not self.HandleModifiersManually then self:ModifiersPreEvent('OnDraw', draw_type) end
 
 			if self.IgnoreZ then cam.IgnoreZ(true) end
-			if self.blend_override then
+			-- GMOD Bug: Translucent parts don't play nicely with blend overrides. Multicore rendering bug?
+			if self.blend_override and not (self.Translucent == true or self.force_translucent == true) then
 				render.OverrideBlendFunc(true,
 					self.blend_override[1],
 					self.blend_override[2],


### PR DESCRIPTION
Haven't tested yet but should be good, I'll leave here anyway to see if anyone has suggestions. I don't see any immediate issues with the pipeline so I'm assuming its a gmod multicore bug, but might need to look deeper into how translucent parts work.