### PR TITLE
part_pool: Check for null owner in OnEntityCreated

### DIFF
--- a/lua/pac3/core/client/part_pool.lua
+++ b/lua/pac3/core/client/part_pool.lua
@@ -405,6 +405,7 @@ pac.AddHook("OnEntityCreated", function(ent)
 	if not IsActuallyValid(ent) then return end
 
 	local owner = ent:GetOwner()
+	if not IsValid(owner) then return end
 
 	for _, part in pairs(parts_from_ent(owner)) do
 		if not part:HasParent() then


### PR DESCRIPTION
To fix this error:
```
[ERROR] addons/pac3-master/lua/pac3/core/client/part_pool.lua:44: Player is NULL(!?)
  1. UniqueID - [C]:-1
   2. parts_from_ent - addons/pac3-master/lua/pac3/core/client/part_pool.lua:44
    3. fn - addons/pac3-master/lua/pac3/core/client/part_pool.lua:393
     4. unknown - addons/ulib-master/lua/ulib/shared/hook.lua:110
```