### PR TITLE
fixed the lagger exploit

### DIFF
--- a/lua/pac3/editor/server/wear.lua
+++ b/lua/pac3/editor/server/wear.lua
@@ -300,7 +300,11 @@ end
 
 util.AddNetworkString("pac_submit")
 
-pace.PCallNetReceive(net.Receive, "pac_submit", function(_, ply)
+pace.PCallNetReceive(net.Receive, "pac_submit", function(len,ply)
+	if len==0 or ply["pac_submit"]==CurTime() then --if they sent an empty net message or sent it more than once per frame
+		return -- block the code below from running
+	end
+	ply["pac_submit"]=CurTime() --note the last time the sent a net message on this string
 	local data = pace.net.DeserializeTable()
 	pace.HandleReceivedData(ply, data)
 end)


### PR DESCRIPTION
before the change, people can lag a server by spamming the "pac_submit" net message, they'd send this message to the server tens of thousands of times in a frame every half second.
now we make it so the function can be executed only once per frame, per player. i've tested it on pony withers and it does work