### PR TITLE
v2 of the fix

### DIFF
--- a/lua/pac3/editor/server/wear.lua
+++ b/lua/pac3/editor/server/wear.lua
@@ -300,7 +300,17 @@ end
 
 util.AddNetworkString("pac_submit")
 
-pace.PCallNetReceive(net.Receive, "pac_submit", function(_, ply)
+pace.PCallNetReceive(net.Receive, "pac_submit", function(len,ply)
+	ply["pac_submit"]=ply["pac_submit"] or 0
+	if len<100 or ply["pac_submit"]>100 then
+		return
+	end
+	ply["pac_submit"]=ply["pac_submit"]+1
+	if ply["pac_submit"]==1 then
+		timer.Simple(0.1,function()
+			ply["pac_submit"]=0
+		end)
+	end
 	local data = pace.net.DeserializeTable()
 	pace.HandleReceivedData(ply, data)
 end)


### PR DESCRIPTION
due to bad networking practices the method of limiting a player to one net message per frame would block PAC3s that have multiple groups from loading correctly.
this method checks to see if they sent more that 100 in a 0.1 second time frame