### PR TITLE
add depot to file.Time to fix error

### DIFF
--- a/lua/pac3/editor/client/saved_parts.lua
+++ b/lua/pac3/editor/client/saved_parts.lua
@@ -63,7 +63,7 @@ function pace.SaveParts(name, prompt_name, override_part)
 					local targetFiles = {}
 
 					for i, filename in ipairs(files) do
-						local time = file.Time("pac3/__backup_save/" .. filename)
+						local time = file.Time("pac3/__backup_save/" .. filename, "DATA")
 						table.insert(targetFiles, {"pac3/__backup_save/" .. filename, time})
 					end
 


### PR DESCRIPTION
`ERR: lua/pac3/editor/client/saved_parts.lua:66: bad argument #2 to 'Time' (string expected, got no value)`