### PR TITLE
Gravity fix

### DIFF
--- a/lua/pac3/core/client/parts/physics.lua
+++ b/lua/pac3/core/client/parts/physics.lua
@@ -69,6 +69,10 @@ function PART:SetRadius(n)
 	end
 
 	self.phys = ent:GetPhysicsObject()
+	
+	if self.Gravity ~= nil then
+		self.phys:EnableGravity(self.Gravity)
+	end
 end
 
 function PART:SetGravity(b)


### PR DESCRIPTION
Re-applies gravity setting when physics object is recreated

This fixes issue [#708](https://github.com/CapsAdmin/pac3/issues/708)