### PR TITLE
Regex fix for GetNiceName

### DIFF
--- a/lua/pac3/core/client/parts/beam.lua
+++ b/lua/pac3/core/client/parts/beam.lua
@@ -108,7 +108,7 @@ pac.StartStorableVars()
 pac.EndStorableVars()
 
 function PART:GetNiceName()
-	return pac.PrettifyName(("/" .. self:GetMaterial()):match(".+/(.+)"):gsub("%..+", "")) or "error"
+	return pac.PrettifyName(("/" .. self:GetMaterial()):match(".*/(.+)"):gsub("%..+", "")) or "error"
 end
 
 function PART:Initialize()


### PR DESCRIPTION
Fixes the regex used in beam PART:GetNiceName to allow the use of custom materials on beam parts

This fixes issue [#711](https://github.com/CapsAdmin/pac3/issues/711)