### PR TITLE
Disable Bone HideMesh functionality to prevent crashes

### DIFF
--- a/lua/pac3/core/client/parts/bone.lua
+++ b/lua/pac3/core/client/parts/bone.lua
@@ -21,8 +21,8 @@ pac.StartStorableVars()
 		pac.GetSet(PART, "AlternativeBones", false)
 		pac.GetSet(PART, "MoveChildrenToOrigin", false)
 		pac.GetSet(PART, "FollowAnglesOnly", false)
-		pac.GetSet(PART, "HideMesh", false)
-		pac.GetSet(PART, "InvertHideMesh", false)
+		--pac.GetSet(PART, "HideMesh", false)
+		--pac.GetSet(PART, "InvertHideMesh", false)
 		pac.SetupPartName(PART, "FollowPart")
 
 	pac.SetPropertyGroup(PART, "orientation")
@@ -256,7 +256,8 @@ function PART:OnBuildBonePositions()
 
 	local scale
 
-	if self.HideMesh then
+	-- Disable hide mesh functionality completely until the crash this causes, is fixed
+	if self.HideMesh and false then
 		scale = inf_scale
 
 		if self.InvertHideMesh then


### PR DESCRIPTION
Disables the functionality of the hide mesh property of the bone part, until a complete fix can be found. 

When this hide mesh property is enabled on the bone part, if the player dies, depending on the bone its linked to, it can cause the physics engine to throw unhandled exceptions, completely hang the hl2 process, and other undefined behaviors. This could be very destructive as players can enter servers with Pac3 and cause all players nearby to crash, with minimal effort.

This is caused by setting the bone scale to scale_inf which is a vector with math.huge in x,y and z. This somehow becomes a problem for the engine when the player dies. It may be possible to reset the scale of the bones just before the player is turned into a rag doll but I haven't been able to come up with a solution that works other then simply disabling the property entirely. 

This fixes issue [#722](https://github.com/CapsAdmin/pac3/issues/722)