### PR TITLE
Reset mat viewer when hovering on unset texture property

### DIFF
--- a/lua/pac3/editor/client/panels/extra_properties.lua
+++ b/lua/pac3/editor/client/panels/extra_properties.lua
@@ -359,8 +359,10 @@ do -- materials and textures
 			pace_material_display = CreateMaterial('pace_material_display', "UnlitGeneric", {})
 		end
 
-		if pace.current_part[self.CurrentKey] and pace.current_part[self.CurrentKey] ~= "" then
-			if not string.find(pace.current_part[self.CurrentKey], '^https?://') then
+		if pace.current_part[self.CurrentKey] then
+			if pace.current_part[self.CurrentKey] == "" then
+				pace_material_display:SetTexture("$basetexture", "models/debug/debugwhite")
+			elseif not string.find(pace.current_part[self.CurrentKey], '^https?://') then
 				pace_material_display:SetTexture("$basetexture", pace.current_part[self.CurrentKey])
 			else
 				local function callback(mat, tex)


### PR DESCRIPTION
Resets the material of the viewer to white, when hovering over an unset texture property. 
This fixes: #698 