### PR TITLE
Prevent 0 prefixed strings becoming numbers

### DIFF
--- a/lua/pac3/libraries/netx.lua
+++ b/lua/pac3/libraries/netx.lua
@@ -71,7 +71,7 @@ local function writeTyped(val, key)
 	if tp == 'string' then
 		local tryuid = tonumber(val)
 
-		if tryuid and tryuid > 0 and tryuid < 2 ^ 32 and math.floor(tryuid) == tryuid then
+		if tryuid and tryuid > 0 and tryuid < 2 ^ 32 and math.floor(tryuid) == tryuid and !(string.len(val) > 1 && string.sub(val, 1, 1) == "0") then
 			net.WriteUInt(TYPE_NUMBER_UID, TYPES_BITS)
 			net.WriteUInt(tryuid, 32)
 		else

--- a/lua/pac3/libraries/netx.lua
+++ b/lua/pac3/libraries/netx.lua
@@ -71,7 +71,7 @@ local function writeTyped(val, key)
 	if tp == 'string' then
 		local tryuid = tonumber(val)
 
-		if tryuid and tryuid > 0 and tryuid < 2 ^ 32 and math.floor(tryuid) == tryuid and !(string.len(val) > 1 && string.sub(val, 1, 1) == "0") then
+		if tryuid and tryuid > 0 and tryuid < 2 ^ 32 and math.floor(tryuid) == tryuid and tostring(tryuid) == val then
 			net.WriteUInt(TYPE_NUMBER_UID, TYPES_BITS)
 			net.WriteUInt(tryuid, 32)
 		else


### PR DESCRIPTION
Fixes issue #756 

When strings which are also valid integers are used as names, they are converted to TYPE_NUMBER_UID mistakenly, causing string properties to be converted into numbers

The fix prevents any strings that are longer than 1 character and begin with 0, from being converted