### PR TITLE
Improved description of flex property RootOwner

### DIFF
--- a/lua/pac3/core/client/parts/flex.lua
+++ b/lua/pac3/core/client/parts/flex.lua
@@ -19,7 +19,7 @@ pac.StartStorableVars()
 	})
 
 	pac.GetSet(PART, "Weight", 0)
-	pac.GetSet(PART, "RootOwner", true)
+	pac.GetSet(PART, "RootOwner", false, { description = "Target the local player instead of the part's parent" })
 	pac.GetSet(PART, "DefaultOnHide", true)
 pac.EndStorableVars()
 


### PR DESCRIPTION
Added a description to the RootOwner property, to prevent confusion
Changed the default value of RootOwner to false, to match the functionality of other parts

This is to help prevent confusion as seen with issue #749 