### PR TITLE
Not supposed to be 'length'?

### DIFF
--- a/lua/pac3/core/shared/http.lua
+++ b/lua/pac3/core/shared/http.lua
@@ -105,7 +105,7 @@ function pac.HTTPGet(url, cb, failcb)
 					if length <= (limit * 1024) then
 						get(url, cb, failcb)
 					else
-						failcb("download is too big (" .. string.NiceSize(len) .. ")", true)
+						failcb("download is too big (" .. string.NiceSize(length) .. ")", true)
 					end
 				else
 					local allow_no_contentlength = SV_NO_CLENGTH:GetInt()


### PR DESCRIPTION
During my digging trough the Logs i have discovered this error.

```
[ERROR] lua/includes/extensions/string.lua:261: attempt to compare nil with number
1. NiceSize - lua/includes/extensions/string.lua:261
2. unknown - addons/pac3_dev/lua/pac3/core/shared/http.lua:108
```
'len' is not existing, so it must be 'length'?
