### PR TITLE
Fixed Save Shortcut

### DIFF
--- a/lua/pac3/editor/client/shortcuts.lua
+++ b/lua/pac3/editor/client/shortcuts.lua
@@ -1,7 +1,8 @@
 function pace.OnShortcutSave()
 	if pace.current_part:IsValid() then
-		-- local part = pace.current_part:GetRootPart() -- Is this even needed?
-		pace.SaveParts()
+		local part = pace.current_part:GetRootPart()
+		local prompt_name = pace.LastSaveName or part:GetName() or "my outfit"
+		pace.SaveParts(nil, prompt_name)
 		surface.PlaySound("buttons/button9.wav")
 	end
 end

--- a/lua/pac3/editor/client/shortcuts.lua
+++ b/lua/pac3/editor/client/shortcuts.lua
@@ -1,7 +1,7 @@
 function pace.OnShortcutSave()
 	if pace.current_part:IsValid() then
-		local part = pace.current_part:GetRootPart()
-		pace.SavePartToFile(part, part:GetName())
+		-- local part = pace.current_part:GetRootPart() -- Is this even needed?
+		pace.SaveParts()
 		surface.PlaySound("buttons/button9.wav")
 	end
 end


### PR DESCRIPTION
During my digging trough the Logs i have discovered this error.

```
[ERROR] addons/pac3_dev/lua/pac3/editor/client/shortcuts.lua:4: attempt to call field 'SavePartToFile' (a nil value)
  1. Call - addons/pac3_dev/lua/pac3/editor/client/shortcuts.lua:4
   2. nextevent - addons/pac3_dev/lua/pac3/editor/client/shortcuts.lua:24
    3. unknown - lua/dlib/modules/hook.lua:1067
```

`pace.SavePartToFile()` Does not seem to exist, also not in the source code. So then `pace.SaveParts()` is used, but I'm not 100% sure if it's meant to be used like that. It seems that `pace.SavePartToFile()` only saves the selected part and not all parts.

Besides, is CTRL + M not intended as a kind of quicksave?