### PR TITLE
Some changes to shortcuts

### DIFF
--- a/lua/pac3/editor/client/shortcuts.lua
+++ b/lua/pac3/editor/client/shortcuts.lua
@@ -21,14 +21,8 @@ function pace.CheckShortcuts()
 	if not pace.Editor or not pace.Editor:IsValid() then return end
 	if last > RealTime() or input.IsMouseDown(MOUSE_LEFT) then return end
 
-	if input.IsKeyDown(KEY_LCONTROL) and input.IsKeyDown(KEY_S) then
-		pace.Call("ShortcutSave")
-		last = RealTime() + 0.2
-	end
-
-	-- CTRL + (W)ear?
-	if input.IsKeyDown(KEY_LCONTROL) and input.IsKeyDown(KEY_N) then
-		pace.Call("ShortcutWear")
+	if input.IsKeyDown(KEY_LALT) and input.IsKeyDown(KEY_E) then
+		pace.Call("ToggleFocus", true)
 		last = RealTime() + 0.2
 	end
 
@@ -37,27 +31,37 @@ function pace.CheckShortcuts()
 		last = RealTime() + 0.2
 	end
 
-	if input.IsKeyDown(KEY_LCONTROL) and input.IsKeyDown(KEY_T) then
-		pace.SetTPose(not pace.GetTPose())
-		last = RealTime() + 0.2
-	end
-
-	if input.IsKeyDown(KEY_LALT) and input.IsKeyDown(KEY_E) then
-		pace.Call("ToggleFocus", true)
-		last = RealTime() + 0.2
-	end
-
-	if input.IsKeyDown(KEY_LCONTROL) and input.IsKeyDown(KEY_F) then
-		pace.properties.search:SetVisible(true)
-		pace.properties.search:RequestFocus()
-		pace.properties.search:SetEnabled(true)
-		pace.property_searching = true
-
-		last = RealTime() + 0.2
-	end
-
 	if input.IsKeyDown(KEY_LALT) and input.IsKeyDown(KEY_LCONTROL) and input.IsKeyDown(KEY_P) then
 		RunConsoleCommand("pac_restart")
+	end
+
+	-- Only if the editor is in the foreground
+	if pace.Editor:HasFocus() then
+		if input.IsKeyDown(KEY_LCONTROL) and input.IsKeyDown(KEY_S) then
+			pace.Call("ShortcutSave")
+			last = RealTime() + 0.2
+		end
+
+		-- CTRL + (W)ear?
+		if input.IsKeyDown(KEY_LCONTROL) and input.IsKeyDown(KEY_N) then
+			pace.Call("ShortcutWear")
+			last = RealTime() + 0.2
+		end
+
+		if input.IsKeyDown(KEY_LCONTROL) and input.IsKeyDown(KEY_T) then
+			pace.SetTPose(not pace.GetTPose())
+			last = RealTime() + 0.2
+		end
+
+		if input.IsKeyDown(KEY_LCONTROL) and input.IsKeyDown(KEY_F) then
+			pace.properties.search:SetVisible(true)
+			pace.properties.search:RequestFocus()
+			pace.properties.search:SetEnabled(true)
+			pace.property_searching = true
+
+			last = RealTime() + 0.2
+		end
+
 	end
 end
 


### PR DESCRIPTION
Make some shortcuts available only if the editor is in the foreground,
This should prevent e.g. the accidental saving during the free view.