### PR TITLE
Added CVar to opt-out of using 'camera' and 'player_eyes' as a bone

### DIFF
--- a/lua/pac3/core/client/bones.lua
+++ b/lua/pac3/core/client/bones.lua
@@ -5,7 +5,7 @@ local Angle = Angle
 local Vector = Vector
 local util_QuickTrace = util.QuickTrace
 local pac = pac
-local pac_isCameraAllowed = pac.CreateClientConVarFast("pac_allow_camera_bone", "1", true, "boolean")
+local pac_isCameraAllowed = pac.CreateClientConVarFast("pac_enable_camera_as_bone", "1", true, "boolean")
 
 pac.BoneNameReplacements =
 {


### PR DESCRIPTION
This lets players disallow outfits from using the local player's `EyePos()` and `EyeAngles()` with the cvar `pac_allow_camera_bone`