### PR TITLE
check if UniqueID function exist

### DIFF
--- a/lua/pac3/core/client/parts/custom_animation.lua
+++ b/lua/pac3/core/client/parts/custom_animation.lua
@@ -34,7 +34,7 @@ function PART:GetNiceName()
 end
 
 function PART:GetAnimID()
-	return "pac_anim_" .. (self:GetPlayerOwner():IsValid() and self:GetPlayerOwner():UniqueID() or "") .. self:GetUniqueID()
+	return "pac_anim_" .. (self:GetPlayerOwner():IsValid() and self:GetPlayerOwner().UniqueID and self:GetPlayerOwner():UniqueID() or "") .. self:GetUniqueID()
 end
 
 function PART:SetRate(num)


### PR DESCRIPTION
I'm not sure how the error gers triggerd, but I guess it's because the player or outfit isn't fully loaded.

> addons/pac3-develop/lua/pac3/core/client/parts/custom_animation.lua:37: attempt to call method 'UniqueID' (a nil value)

This was found while playing on the Gamemode Jazztronauts
The errors occured on the of the cutscenes.
Steps to Reproduce.
1. Get the lastest Dev version of pac3
2. Subscribe to the Addons of Jazztronauts ([Collection](https://steamcommunity.com/workshop/filedetails/?id=1455883814))
3. Launch the map jazz_bar
4. Load a pac with custom animation part
5. Try a cutscene.

