### PR TITLE
Disabled the language ID indicator

### DIFF
--- a/lua/pac3/editor/client/menu_bar.lua
+++ b/lua/pac3/editor/client/menu_bar.lua
@@ -87,6 +87,7 @@ local function populate_options(menu)
 	menu:AddSpacer()
 
 	menu:AddCVar(L"automatic property size", "pac_auto_size_properties", "1", "0")
+	menu:AddCVar(L"enable language identifier in text fields", "pac_editor_languageid", "1", "0")
 	pace.AddLanguagesToMenu(menu)
 	pace.AddFontsToMenu(menu)
 

--- a/lua/pac3/editor/client/panels/properties.lua
+++ b/lua/pac3/editor/client/panels/properties.lua
@@ -921,6 +921,7 @@ do -- base editable
 		pnl:SetDrawBorder(false)
 		pnl:SetValue(self.original_str or "")
 		pnl:SetKeyboardInputEnabled(true)
+		pnl:SetDrawLanguageID(false)
 		pnl:RequestFocus()
 		pnl:SelectAllOnFocus(true)
 

--- a/lua/pac3/editor/client/panels/properties.lua
+++ b/lua/pac3/editor/client/panels/properties.lua
@@ -1,5 +1,7 @@
 local L = pace.LanguageString
 
+local languageID = CreateClientConVar("pac_editor_languageid", 1, true, false, "Whether we should show the language indicator inside of editable text entries.")
+
 function pace.ShowSpecial(pnl, parent, size)
 	size = size or 150
 
@@ -921,7 +923,7 @@ do -- base editable
 		pnl:SetDrawBorder(false)
 		pnl:SetValue(self.original_str or "")
 		pnl:SetKeyboardInputEnabled(true)
-		pnl:SetDrawLanguageID(false)
+		pnl:SetDrawLanguageID(languageID:GetBool())
 		pnl:RequestFocus()
 		pnl:SelectAllOnFocus(true)
 


### PR DESCRIPTION
It was constantly getting in the way, hiding up to 2-3 characters. I'm supriced nobody did this long ago.