### PR TITLE
Fix SetupMove usage

### DIFF
--- a/lua/pac3/core/shared/entity_mutator.lua
+++ b/lua/pac3/core/shared/entity_mutator.lua
@@ -318,11 +318,10 @@ if SERVER then
 		end
 	end
 
-	hook.Add("PlayerInitialSpawn", "pac_entity_mutators_spawn", function( ply)
+	hook.Add("PlayerInitialSpawn", "pac_entity_mutators_spawn", function(ply)
 		local id = "pac_entity_mutators_spawn" .. ply:UniqueID()
-		hook.Add( "SetupMove", id, function(self, ply, _, cmd)
-			if self == ply and not cmd:IsForced() then
-
+		hook.Add( "SetupMove", id, function(movingPly, _, cmd)
+			if movingPly == ply and not cmd:IsForced() then
 				emut.ReplicateMutatorsForPlayer(ply)
 
 				hook.Remove("SetupMove", id)


### PR DESCRIPTION
While investigating a performance issue on my server, I was looking through some hooks and noticed a ton of PAC hooks on `SetupMove`. After clearing them all, the lag we saw disappeared.

I don't know if removing those hooks actually fixed the performance problems - I certainly don't see anything in here that would be causing problems, but that's my anecdote. (We were experiencing large lag spikes every time the GC collected)

Either way, I don't think the current usage of `SetupMove` is correct.
https://wiki.facepunch.com/gmod/GM:SetupMove

The hook sends 3 parameters, `Player, CMoveData, CUserCmd`.
The existing code expects four arguments, discards one it cares about, and shadows `ply` which is needed for comparison (I _think_)

As a result, the hooks likely never get cleared, and the mutators are not replicated.

I'm not very good at PAC so I'm not 100% sure how to test this properly. Some help or guidance would be appreciated.

(P.S should I point this at the dev branch instead?)
