### PR TITLE
Don't use "none" when setting cursors.

### DIFF
--- a/lua/pac3/editor/client/animation_timeline.lua
+++ b/lua/pac3/editor/client/animation_timeline.lua
@@ -864,7 +864,7 @@ do
 				self.size_x = nil
 				self.size_w = nil
 				self:MouseCapture(false)
-				self:SetCursor("none")
+				self:SetCursor("sizewe")
 				timeline.Save()
 			elseif self.move then
 				local panels = {}
@@ -892,7 +892,7 @@ do
 				end
 
 				self:MouseCapture(false)
-				self:SetCursor("none")
+				self:SetCursor("hand")
 				self.move = nil
 				self.move_x = nil
 				timeline.frame.moving = false

--- a/lua/pac3/editor/client/view.lua
+++ b/lua/pac3/editor/client/view.lua
@@ -110,7 +110,7 @@ function pace.GUIMouseReleased(mc)
 	isHoldingMovement = false
 
 	if IsValid(hoveredPanelCursor) then
-		hoveredPanelCursor:SetCursor('none')
+		hoveredPanelCursor:SetCursor('arrow')
 		hoveredPanelCursor = nil
 	end
 


### PR DESCRIPTION
'none' causes cursor flicker and framerate drops (might be hard to notice but on high framerates it's very obvious)

