### PR TITLE
Let some special bones be animated

### DIFF
--- a/lua/pac3/core/client/bones.lua
+++ b/lua/pac3/core/client/bones.lua
@@ -421,9 +421,13 @@ do -- bone manipulation for boneanimlib
 
 	function pac.ManipulateSpecialBone(ent, boneID, pos, ang)
 		if(ent.pac_special_bone_anims and ent.pac_special_bone_anims[boneID])then
-			local matrix = ent.pac_special_bone_anims[boneID]
-			pos = pos + matrix:GetTranslation()
-			ang = ang + matrix:GetAngles()
+			local mMatrix = Matrix()
+			mMatrix:SetTranslation(pos)
+			mMatrix:SetAngles(ang)
+
+			mMatrix = mMatrix * ent.pac_special_bone_anims[boneID]
+			pos = mMatrix:GetTranslation()
+			ang = mMatrix:GetAngles()
 
 			return pos, ang
 		end

--- a/lua/pac3/editor/client/animation_timeline.lua
+++ b/lua/pac3/editor/client/animation_timeline.lua
@@ -125,7 +125,7 @@ function timeline.EditBone()
 
 	if not timeline.selected_bone then
 		for k, v in pairs(boneData) do
-			if not v.is_special and not v.is_attachment then
+			if v.force_movable or (not v.is_special and not v.is_attachment) then
 				timeline.selected_bone = v.real
 				break
 			end
@@ -266,7 +266,7 @@ function timeline.Open(part)
 				timeline.selected_bone = boneData[val] and boneData[val].real or false
 				if not timeline.selected_bone then
 					for k, v in pairs(boneData) do
-						if not v.is_special and not v.is_attachment then
+						if v.force_movable or (not v.is_special and not v.is_attachment) then
 							timeline.selected_bone = v.real
 							break
 						end

--- a/lua/pac3/editor/client/select.lua
+++ b/lua/pac3/editor/client/select.lua
@@ -297,14 +297,14 @@ function pace.SelectBone(ent, callback, only_movable)
 
 		if models then
 			for k, v in pairs(tbl) do
-				if not v.bone then
+				if not v.force_movable and not v.bone then
 					tbl[k] = nil
 				end
 			end
 		end
 
 		for k, v in pairs(tbl) do
-			if v.is_special or not RENDER_ATTACHMENTS:GetBool() and v.is_attachment then
+			if not v.force_movable and (v.is_special or not RENDER_ATTACHMENTS:GetBool() and v.is_attachment) then
 				tbl[k] = nil
 			end
 		end
@@ -326,7 +326,7 @@ function pace.SelectBone(ent, callback, only_movable)
 		callback,
 
 		function (key, val)
-			if val.is_special or val.is_attachment then return end
+			if not val.force_movable and (val.is_special or val.is_attachment) then return end
 			ent.pac_bones_select_target = val.i
 		end,
 


### PR DESCRIPTION
Hey hey,

**Summary: With this PR I show how few modifications are needed to allow those special (fake) bones to animate**

So I ran into a bit of a struggle making a skateboard outfit. I wanted to create a Custom Animation to animate tricks, though binding to existing bones caused the skateboard to move with the players' body and breath.
Having the skateboard completely separate and having two Custom Animations was a hassle to synchronize, since board movement and feet/leg movement are closely related in skateboarding.

I wanted to use a "fake" bone which is not actually bound to the model. More like the special bones (skirt2, pos_ang, etc.) defined in `core/client/bones.lua`, but those were impossible to animate.

I've written up a prototype which allows select special bones to be animated. It is just an initial prototype/concept, please do comment on what you think of it and how you'd like to see this implemented. A point of improvement I think would be valuable would be the ability to add "Special Bones" through hooks, or perhaps even through the pac editor.

I hope I've made clear why this can be useful, here's some additional screenshots I took:

![bind to a special bone (was already possible)](https://user-images.githubusercontent.com/2738114/117884703-3f899680-b2ad-11eb-83cc-cab46742b293.png)
![animate the special bone (new)](https://user-images.githubusercontent.com/2738114/117884697-3d273c80-b2ad-11eb-92ff-054cc2fb2b40.png)
![have the model animate completely independently from the model](https://user-images.githubusercontent.com/2738114/117885083-af981c80-b2ad-11eb-9004-48359d447efe.gif)

