### PR TITLE
Allow extracting the bone orientations from a selected animation keyframe

### DIFF
--- a/lua/pac3/core/client/bones.lua
+++ b/lua/pac3/core/client/bones.lua
@@ -27,6 +27,21 @@ pac.BoneNameReplacements =
 	{" L", " left"},
 }
 
+function pac.GetFriendlyBoneName(boneName)
+	local friendly = boneName
+
+	for _, value in pairs(pac.BoneNameReplacements) do
+		friendly = friendly:gsub(value[1], value[2])
+	end
+
+	friendly = friendly
+	:Trim()
+	:lower()
+	:gsub("(.-)(%d+)", "%1 %2")
+
+	return friendly
+end
+
 function pac.GetAllBones(ent)
 	ent = ent or NULL
 
@@ -40,17 +55,9 @@ function pac.GetAllBones(ent)
 
 		for bone = 0, count do
 			local name = ent:GetBoneName(bone)
-			local friendly = name
 
 			if name then
-				for _, value in pairs(pac.BoneNameReplacements) do
-					friendly = friendly:gsub(value[1], value[2])
-				end
-
-				friendly = friendly
-				:Trim()
-				:lower()
-				:gsub("(.-)(%d+)", "%1 %2")
+				local friendly = pac.GetFriendlyBoneName(name)
 
 				local parent_i = ent:GetBoneParent(bone)
 				if parent_i == -1 then

--- a/lua/pac3/core/client/bones.lua
+++ b/lua/pac3/core/client/bones.lua
@@ -421,9 +421,13 @@ do -- bone manipulation for boneanimlib
 
 	function pac.ManipulateSpecialBone(ent, boneID, pos, ang)
 		if(ent.pac_special_bone_anims and ent.pac_special_bone_anims[boneID])then
-			local matrix = ent.pac_special_bone_anims[boneID]
-			pos = pos + matrix:GetTranslation()
-			ang = ang + matrix:GetAngles()
+			local mMatrix = Matrix()
+			mMatrix:SetTranslation(pos)
+			mMatrix:SetAngles(ang)
+
+			mMatrix = mMatrix * ent.pac_special_bone_anims[boneID]
+			pos = mMatrix:GetTranslation()
+			ang = mMatrix:GetAngles()
 
 			return pos, ang
 		end

--- a/lua/pac3/editor/client/animation_timeline.lua
+++ b/lua/pac3/editor/client/animation_timeline.lua
@@ -125,7 +125,7 @@ function timeline.EditBone()
 
 	if not timeline.selected_bone then
 		for k, v in pairs(boneData) do
-			if not v.is_special and not v.is_attachment then
+			if v.force_movable or (not v.is_special and not v.is_attachment) then
 				timeline.selected_bone = v.real
 				break
 			end
@@ -266,7 +266,7 @@ function timeline.Open(part)
 				timeline.selected_bone = boneData[val] and boneData[val].real or false
 				if not timeline.selected_bone then
 					for k, v in pairs(boneData) do
-						if not v.is_special and not v.is_attachment then
+						if v.force_movable or (not v.is_special and not v.is_attachment) then
 							timeline.selected_bone = v.real
 							break
 						end

--- a/lua/pac3/editor/client/select.lua
+++ b/lua/pac3/editor/client/select.lua
@@ -297,14 +297,14 @@ function pace.SelectBone(ent, callback, only_movable)
 
 		if models then
 			for k, v in pairs(tbl) do
-				if not v.bone then
+				if not v.force_movable and not v.bone then
 					tbl[k] = nil
 				end
 			end
 		end
 
 		for k, v in pairs(tbl) do
-			if v.is_special or not RENDER_ATTACHMENTS:GetBool() and v.is_attachment then
+			if not v.force_movable and (v.is_special or not RENDER_ATTACHMENTS:GetBool() and v.is_attachment) then
 				tbl[k] = nil
 			end
 		end
@@ -326,7 +326,7 @@ function pace.SelectBone(ent, callback, only_movable)
 		callback,
 
 		function (key, val)
-			if val.is_special or val.is_attachment then return end
+			if not val.force_movable and (val.is_special or val.is_attachment) then return end
 			ent.pac_bones_select_target = val.i
 		end,
 

--- a/lua/pac3/editor/client/tools.lua
+++ b/lua/pac3/editor/client/tools.lua
@@ -751,7 +751,8 @@ pace.AddTool(L"populate with dummy bones", function(part,suboption)
 	pace.RefreshTree(true)
 end)
 
-pace.AddTool(L"extract bones from current animation frame", function(part, suboption)
+pace.AddTool(L"extract bones from current animation frame", function(_, suboption)
+	local part = pace.timeline.animation_part
   local targetFrame = pace.timeline.selected_keyframe
 
 	targetFrame = targetFrame.DataTable

--- a/lua/pac3/editor/client/tools.lua
+++ b/lua/pac3/editor/client/tools.lua
@@ -751,21 +751,23 @@ pace.AddTool(L"populate with dummy bones", function(part,suboption)
 	pace.RefreshTree(true)
 end)
 
-pace.AddTool(L"extract bones to new group from final animation frame", function(part, suboption)
-	if(part.ClassName ~= "custom_animation")then
-		Derma_Message("You must select a custom animation to generate the bones from the final frame of that animation.","Error: Must Select Custom Animation","OK")
+pace.AddTool(L"extract bones from current animation frame", function(part, suboption)
+  local targetFrame = pace.timeline.selected_keyframe
+
+	targetFrame = targetFrame.DataTable
+
+	if(not targetFrame)then
+		Derma_Message("You must select a Custom Animation keyframe in order to extract the bones from it.","Error: Must Select Custom Animation keyframe","OK")
 		return
 	end
 
 	local ent = part:GetOwner()
-  local animation = pac.animations.registered[part:GetAnimID()]
-  local lastFrame = animation.FrameData[#animation.FrameData]
 	local bones = pac.GetModelBones(ent)
 
   local root = pac.CreatePart("group")
   root:SetName("animation \""..part:GetName().."\" final bones")
 	
-  for iBoneID, boneData in pairs(lastFrame.BoneInfo) do
+  for iBoneID, boneData in pairs(targetFrame.BoneInfo) do
 		iBoneID = pac.GetFriendlyBoneName(iBoneID)
 
 		if(bones[iBoneID] and not bones[iBoneID].is_special)then
@@ -787,6 +789,8 @@ pace.AddTool(L"extract bones to new group from final animation frame", function(
 	end
 	
   pace.RefreshTree(true)
+	pace.current_part_uid = root.UniqueID
+	pace.TrySelectPart()
 end)
 
 pace.AddTool(L"print part info", function(part)


### PR DESCRIPTION
_(Note: The code in this PR is a continuation of the commits I made for PR #1069)_

I couldn't find a way to copy the orientation changes I applied in a Custom Animation to my model. In one example I had transitioned the model to a pose that I'd like to continue building a different outfit from. It was a skateboarding pose from riding (standing up) to moving down to just before doing a trick. That pose of "about to do a trick" is something I'd like in another outfit, from which I'll transition to tricks (e.g: about to do a trick > kickflip, etc...)

This way I can create sets of animations more easily and I'll know 100% certain they align with other animations/poses.

I've added a tools menu option to extract the bone orientations to a group in root. Here's some screenshots to clarify:

![the process of selecting a keyframe and command the extracting of bones](https://user-images.githubusercontent.com/2738114/117975777-55d83680-b32f-11eb-8126-a336cb9d4063.png)

![the resulting bones in a group](https://user-images.githubusercontent.com/2738114/117975896-77392280-b32f-11eb-933c-f4c71b46ef9c.png)


C & C is appreciated