### PR TITLE
Move ent:SetColor() in contraption to after ent:Spawn().

### DIFF
--- a/lua/pac3/extra/server/contraption.lua
+++ b/lua/pac3/extra/server/contraption.lua
@@ -25,11 +25,11 @@ local function spawn(val,ply)
 	ent:SetModel(model)-- insecure
 	ent:SetPos(val.pos)-- insecure
 	ent:SetAngles(val.ang)-- insecure
-	ent:SetColor(val.clr)
 	ent:SetSkin(val.skn)
 	ent:SetMaterial(val.mat) -- insecure
 	ent:Spawn()
 	ent:SetHealth(9999999)
+	ent:SetColor(val.clr)
 
 	hook.Run("PlayerSpawnedProp", ply, model, ent)
 


### PR DESCRIPTION
SetColor is called before the Entity Spawns, which causes this error.
```
Trace:
	1: Line 32	"Trace"		lua/includes/extensions/debug.lua
	2: Line 40	"nil"		addons/pac3-develop/lua/pac3/editor/server/util.lua
	3: C function	"SetColorOriginal4"
	4: Line 192	"SetColor"		lua/includes/extensions/entity.lua
	5: Line 28	"spawn"		addons/pac3-develop/lua/pac3/extra/server/contraption.lua
	6: Line 113	"nil"		addons/pac3-develop/lua/pac3/extra/server/contraption.lua
	7: C function	"xpcall"
	8: Line 39	"PCallCriticalFunction"		addons/pac3-develop/lua/pac3/editor/server/util.lua
	9: Line 56	"func"		addons/pac3-develop/lua/pac3/editor/server/util.lua
	10: Line 32	"nil"		lua/includes/extensions/net.lua
```