### PR TITLE
Fixed animation

### DIFF
--- a/lua/pac3/core/client/parts/animation.lua
+++ b/lua/pac3/core/client/parts/animation.lua
@@ -264,17 +264,17 @@ function PART:OnUpdateAnimation()
 			return
 		end
 
-		local rate = (duration == 0) and 0 or (self.Rate / duration / math.abs(maxmin) * FrameTime())
+		local rate = (duration == 0) and 0 or (self.Rate / duration / math.abs(maxmin) * FrameTime() * 0.5)
 
 		if self.PingPongLoop then
-			self.frame = (self.frame + rate * 0.25) % 1
-			local cycle = min + math.abs(1 - (self.frame * 2 + 1 + self.Offset) % 2) * maxmin
+			self.frame = (self.frame + rate) % 2
+			local cycle = min + math.abs(1 - (self.frame + 1 + self.Offset) % 2) * maxmin
 
 			if pac.IsNumberValid(cycle) then
 				ent:SetCycle(self.InvertFrames and (1 - cycle) or cycle)
 			end
 		else
-			self.frame = (self.frame + rate * 0.5) % 1
+			self.frame = (self.frame + rate) % 2
 			local cycle = min + (self.frame + self.Offset) % 1 * maxmin
 
 			if pac.IsNumberValid(cycle) then

--- a/lua/pac3/core/client/parts/animation.lua
+++ b/lua/pac3/core/client/parts/animation.lua
@@ -267,14 +267,22 @@ function PART:OnUpdateAnimation()
 		local rate = (duration == 0) and 0 or (self.Rate / duration / math.abs(maxmin) * FrameTime() * 0.5)
 
 		if self.PingPongLoop then
-			self.frame = (self.frame + rate) % 2
+			if self.Loop then
+				self.frame = (self.frame + rate) % 4
+			else
+				self.frame = (math.min(self.frame + rate, 2)) % 4
+			end
 			local cycle = min + math.abs(1 - (self.frame + 1 + self.Offset) % 2) * maxmin
 
 			if pac.IsNumberValid(cycle) then
 				ent:SetCycle(self.InvertFrames and (1 - cycle) or cycle)
 			end
 		else
-			self.frame = (self.frame + rate) % 2
+			if self.Loop then
+				self.frame = (self.frame + rate) % 4
+			else
+				self.frame = (math.min(self.frame + rate, 1)) % 4
+			end
 			local cycle = min + (self.frame + self.Offset) % 1 * maxmin
 
 			if pac.IsNumberValid(cycle) then

--- a/lua/pac3/core/client/parts/animation.lua
+++ b/lua/pac3/core/client/parts/animation.lua
@@ -233,13 +233,10 @@ function PART:OnUpdateAnimation()
 	if ent:IsValid() then
 		if not self.random_seqname then return end
 
-		local seq = ent:LookupSequence(self.random_seqname) or 0
+		local seq, duration = ent:LookupSequence(self.random_seqname)
 
-		local duration = 0
 		local count = ent:GetSequenceCount() or 0
-		if seq >= 0 and seq < count and count > 0 then
-			duration = ent:SequenceDuration(seq)
-		else
+		if seq < 0 or seq >= count then
 			-- It's an invalid sequence. Don't bother
 			return
 		end
@@ -253,47 +250,52 @@ function PART:OnUpdateAnimation()
 
 			return
 		end
-
-		local rate = math.min(self.Rate * duration, 1)
-
-		if seq ~= -1 then
-
-			if rate == 0 then
-				ent:SetCycle(self.Offset % 1)
-				return
-			end
-		else
-			seq = tonumber(self.random_seqname) or -1
-
-			if seq ~= -1 then
-				if rate == 0 then
-					ent:SetCycle(self.Offset % 1)
-					return
-				end
-			else
-				return
-			end
-		end
-
-		rate = rate / math.abs(self.Min - self.Max)
-		rate = rate * FrameTime()
-
+		
 		local min = self.Min
 		local max = self.Max
+		local maxmin = max - min
+		
+		if min == max then
+			local cycle = min
+
+			if pac.IsNumberValid(cycle) then
+				ent:SetCycle(self.InvertFrames and (1 - cycle) or cycle)
+			end
+			return
+		end
+
+		local rate = (duration == 0) and 0 or (self.Rate / duration)
+
+		if rate == 0 then
+			local cycle
+			if self.PingPongLoop then
+				cycle = min + math.abs(1 - (self.frame * 2 + self.Offset) % 2) * maxmin
+			else
+				cycle = min + (self.frame + self.Offset) % 1 * maxmin
+			end
+		
+			if pac.IsNumberValid(cycle) then
+				ent:SetCycle(self.InvertFrames and (1 - cycle) or cycle)
+			end
+			return
+		end
+
+		rate = rate / math.abs(maxmin)
+		rate = rate * FrameTime()
 
 		if self.PingPongLoop then
-			self.frame = self.frame + rate / 2
-			local cycle = min + math.abs(math.Round((self.frame + self.Offset) * 0.5) - (self.frame + self.Offset) * 0.5) * 2 * (max - min)
+			self.frame = (self.frame + rate * 0.25) % 1
+			local cycle = min + math.abs(1 - (self.frame * 2 + self.Offset) % 2) * maxmin
 
 			if pac.IsNumberValid(cycle) then
-				ent:SetCycle(not self.InvertFrames and cycle or (1 - cycle))
+				ent:SetCycle(self.InvertFrames and (1 - cycle) or cycle)
 			end
 		else
-			self.frame = self.frame + rate
-			local cycle = min + ((self.frame + self.Offset) * 0.5) % 1 * (max - min)
+			self.frame = (self.frame + rate * 0.5) % 1
+			local cycle = min + (self.frame + self.Offset) % 1 * maxmin
 
 			if pac.IsNumberValid(cycle) then
-				ent:SetCycle(not self.InvertFrames and cycle or (1 - cycle))
+				ent:SetCycle(self.InvertFrames and (1 - cycle) or cycle)
 			end
 		end
 	end

--- a/lua/pac3/core/client/parts/animation.lua
+++ b/lua/pac3/core/client/parts/animation.lua
@@ -270,7 +270,7 @@ function PART:OnUpdateAnimation()
 			if self.Loop then
 				self.frame = (self.frame + rate) % 4
 			else
-				self.frame = (math.min(self.frame + rate, 2)) % 4
+				self.frame = math.max(math.min(self.frame + rate, 2), 0)
 			end
 			local cycle = min + math.abs(1 - (self.frame + 1 + self.Offset) % 2) * maxmin
 
@@ -281,7 +281,7 @@ function PART:OnUpdateAnimation()
 			if self.Loop then
 				self.frame = (self.frame + rate) % 4
 			else
-				self.frame = (math.min(self.frame + rate, 1)) % 4
+				self.frame = math.max(math.min(self.frame + rate, 1), 0)
 			end
 			local cycle = min + (self.frame + self.Offset) % 1 * maxmin
 

--- a/lua/pac3/core/client/parts/animation.lua
+++ b/lua/pac3/core/client/parts/animation.lua
@@ -264,24 +264,7 @@ function PART:OnUpdateAnimation()
 			return
 		end
 
-		local rate = (duration == 0) and 0 or (self.Rate / duration)
-
-		if rate == 0 then
-			local cycle
-			if self.PingPongLoop then
-				cycle = min + math.abs(1 - (self.frame * 2 + 1 + self.Offset) % 2) * maxmin
-			else
-				cycle = min + (self.frame + self.Offset) % 1 * maxmin
-			end
-		
-			if pac.IsNumberValid(cycle) then
-				ent:SetCycle(self.InvertFrames and (1 - cycle) or cycle)
-			end
-			return
-		end
-
-		rate = rate / math.abs(maxmin)
-		rate = rate * FrameTime()
+		local rate = (duration == 0) and 0 or (self.Rate / duration / math.abs(maxmin) * FrameTime())
 
 		if self.PingPongLoop then
 			self.frame = (self.frame + rate * 0.25) % 1

--- a/lua/pac3/core/client/parts/animation.lua
+++ b/lua/pac3/core/client/parts/animation.lua
@@ -268,7 +268,7 @@ function PART:OnUpdateAnimation()
 
 		if self.PingPongLoop then
 			if self.Loop then
-				self.frame = (self.frame + rate) % 4
+				self.frame = (self.frame + rate) % 2
 			else
 				self.frame = math.max(math.min(self.frame + rate, 2), 0)
 			end
@@ -279,7 +279,7 @@ function PART:OnUpdateAnimation()
 			end
 		else
 			if self.Loop then
-				self.frame = (self.frame + rate) % 4
+				self.frame = (self.frame + rate) % 2
 			else
 				self.frame = math.max(math.min(self.frame + rate, 1), 0)
 			end

--- a/lua/pac3/core/client/parts/animation.lua
+++ b/lua/pac3/core/client/parts/animation.lua
@@ -269,7 +269,7 @@ function PART:OnUpdateAnimation()
 		if rate == 0 then
 			local cycle
 			if self.PingPongLoop then
-				cycle = min + math.abs(1 - (self.frame * 2 + self.Offset) % 2) * maxmin
+				cycle = min + math.abs(1 - (self.frame * 2 + 1 + self.Offset) % 2) * maxmin
 			else
 				cycle = min + (self.frame + self.Offset) % 1 * maxmin
 			end
@@ -285,7 +285,7 @@ function PART:OnUpdateAnimation()
 
 		if self.PingPongLoop then
 			self.frame = (self.frame + rate * 0.25) % 1
-			local cycle = min + math.abs(1 - (self.frame * 2 + self.Offset) % 2) * maxmin
+			local cycle = min + math.abs(1 - (self.frame * 2 + 1 + self.Offset) % 2) * maxmin
 
 			if pac.IsNumberValid(cycle) then
 				ent:SetCycle(self.InvertFrames and (1 - cycle) or cycle)


### PR DESCRIPTION
- Rate setting now multiplies playback rate so a Rate of 1 is now actually 1x playback speed
- Fixed divide by 0 when Min and Max settings are the same number (doing this now explicitly sets the progress of the animation)
- Setting Rate to 0 now pauses animation like one would expect instead of also setting the current frame to 0
- Removed rate limit that was sometimes so low that animations could not be played at the original speed
- Made self.frame wrap from 0 to 2 so extremely high rates will never become so high they experience floating point precision loss
- Removed some unnecessary code that never ran
- Replaced some code with more optimized alternatives
- Can now disable looping

Everything has been tested by me