### PR TITLE
scale shake amplitude with distance

### DIFF
--- a/lua/pac3/core/client/parts/shake.lua
+++ b/lua/pac3/core/client/parts/shake.lua
@@ -20,7 +20,7 @@ function PART:OnShow(from_rendering)
 		local eyedistance = position:Distance(pac.EyePos)
 		local radius = math.Clamp(self.Radius, 0.0001, 500)
 		
-		local amplitude = (self.Falloff and (1 - (eyedistance / radius) ^ 2) * self.Amplitude) or (eyedistance < radius and self.Amplitude or 0)
+		local amplitude = (self.Falloff and (1 - (eyedistance / radius)) * self.Amplitude) or (eyedistance < radius and self.Amplitude or 0)
 
 		util.ScreenShake(position, amplitude, self.Frequency, math.Clamp(self.Duration, 0.0001, 2), 0)
 	end

--- a/lua/pac3/core/client/parts/shake.lua
+++ b/lua/pac3/core/client/parts/shake.lua
@@ -16,11 +16,11 @@ BUILDER:EndStorableVars()
 
 function PART:OnShow(from_rendering)
 	if not from_rendering then
-		position = self:GetDrawPosition()
-		eyedistance = position:Distance(pac.EyePos)
-		radius = math.Clamp(self.Radius, 0.0001, 500)
+		local position = self:GetDrawPosition()
+		local eyedistance = position:Distance(pac.EyePos)
+		local radius = math.Clamp(self.Radius, 0.0001, 500)
 		
-		amplitude = (self.Falloff and (1 - eyedistance / radius) * self.Amplitude) or (eyedistance < radius and self.Amplitude or 0)
+		local amplitude = (self.Falloff and (1 - (eyedistance / radius) ^ 2) * self.Amplitude) or (eyedistance < radius and self.Amplitude or 0)
 
 		util.ScreenShake(position, amplitude, self.Frequency, math.Clamp(self.Duration, 0.0001, 2), 0)
 	end

--- a/lua/pac3/core/client/parts/shake.lua
+++ b/lua/pac3/core/client/parts/shake.lua
@@ -1,20 +1,28 @@
 local BUILDER, PART = pac.PartTemplate("base_movable")
 
 PART.ClassName = "shake"
-
 PART.Group = 'effects'
 PART.Icon = 'icon16/transmit.png'
 
 BUILDER:StartStorableVars()
-	BUILDER:GetSet("Amplitude", 1)
-	BUILDER:GetSet("Frequency", 1)
-	BUILDER:GetSet("Duration", 0.5)
-	BUILDER:GetSet("Radius", 100)
+	BUILDER:SetPropertyGroup("generic")
+	BUILDER:SetPropertyGroup("shake")
+		BUILDER:GetSet("Amplitude", 1)
+		BUILDER:GetSet("Falloff", false)
+		BUILDER:GetSet("Frequency", 1)
+		BUILDER:GetSet("Duration", 0.5)
+		BUILDER:GetSet("Radius", 100)
 BUILDER:EndStorableVars()
 
 function PART:OnShow(from_rendering)
 	if not from_rendering then
-		util.ScreenShake(self:GetDrawPosition(), self.Amplitude, self.Frequency, math.Clamp(self.Duration, 0.0001, 2), math.Clamp(self.Radius, 0.0001, 500))
+		position = self:GetDrawPosition()
+		eyedistance = position:Distance(pac.EyePos)
+		radius = math.Clamp(self.Radius, 0.0001, 500)
+		
+		amplitude = (self.Falloff and (1 - eyedistance / radius) * self.Amplitude) or (eyedistance < radius and self.Amplitude or 0)
+
+		util.ScreenShake(position, amplitude, self.Frequency, math.Clamp(self.Duration, 0.0001, 2), 0)
 	end
 end
 


### PR DESCRIPTION
A workaround for #1127 
This pretty much creates a fake shake radius by setting amplitude to 0 if the camera distance is higher than the set radius.
Includes optional falloff setting.