### PR TITLE
new material defaults + fixes

### DIFF
--- a/lua/pac3/core/client/parts/material.lua
+++ b/lua/pac3/core/client/parts/material.lua
@@ -136,7 +136,7 @@ for shader_name, groups in pairs(shader_params.shaders) do
 				self["Set" .. k](self, "")
 			end
 		end
-		
+
 		print(str)
 		print("======")
 		PrintTable(vmt)
@@ -156,6 +156,12 @@ for shader_name, groups in pairs(shader_params.shaders) do
 
 						if type(info.default) == "number" then
 							v = v.x
+						end
+					elseif v:find("{", nil, true) then
+						v = Vector(v:gsub("[%{%}]", ""):gsub("%s+", " "):Trim())
+
+						if info.type == "color" then
+							v = v / 255
 						end
 					end
 				end

--- a/lua/pac3/core/client/parts/material.lua
+++ b/lua/pac3/core/client/parts/material.lua
@@ -128,10 +128,15 @@ for shader_name, groups in pairs(shader_params.shaders) do
 
 
 		for k,v in pairs(self:GetVars()) do
-			if PART.ShaderParams[k] and PART.ShaderParams[k].default ~= nil then
-				self["Set" .. k](self, PART.ShaderParams[k].default)
+			local param = PART.ShaderParams[k]
+			if param and param.default ~= nil then
+				self["Set" .. k](self, param.default)
+			end
+			if param and param.type == "texture" then
+				self["Set" .. k](self, "")
 			end
 		end
+		
 		print(str)
 		print("======")
 		PrintTable(vmt)

--- a/lua/pac3/core/client/parts/material.lua
+++ b/lua/pac3/core/client/parts/material.lua
@@ -429,6 +429,13 @@ for shader_name, groups in pairs(shader_params.shaders) do
 							self:GetRawMaterial():SetTexture(key, tex)
 						end, self:GetPlayerOwner()) then
 							self:GetRawMaterial():SetTexture(key, val)
+
+							local texture = self:GetRawMaterial():GetTexture(key)
+
+							if texture then
+								self.vtf_frame_limit = self.vtf_frame_limit or {}
+								self.vtf_frame_limit[group] = texture:GetNumAnimationFrames()
+							end
 						end
 					end
 				end
@@ -459,6 +466,8 @@ for shader_name, groups in pairs(shader_params.shaders) do
 							self[property_name] = val
 							if self.vtf_frame_limit and self.vtf_frame_limit[group] then
 								self:GetRawMaterial():SetInt(key, math.abs(val)%self.vtf_frame_limit[group])
+							else
+								self:GetRawMaterial():SetInt(key, val)
 							end
 						end
 					end
@@ -534,7 +543,6 @@ for shader_name, groups in pairs(shader_params.shaders) do
 				end
 			end
 		end
-
 		return self.Materialm
 	end
 

--- a/lua/pac3/core/client/parts/material.lua
+++ b/lua/pac3/core/client/parts/material.lua
@@ -424,7 +424,7 @@ for shader_name, groups in pairs(shader_params.shaders) do
 						if not pac.resource.DownloadTexture(val, function(tex, frames)
 							if frames then
 								self.vtf_frame_limit = self.vtf_frame_limit or {}
-								self.vtf_frame_limit[group] = frames
+								self.vtf_frame_limit[property_name] = frames
 							end
 							self:GetRawMaterial():SetTexture(key, tex)
 						end, self:GetPlayerOwner()) then
@@ -434,7 +434,7 @@ for shader_name, groups in pairs(shader_params.shaders) do
 
 							if texture then
 								self.vtf_frame_limit = self.vtf_frame_limit or {}
-								self.vtf_frame_limit[group] = texture:GetNumAnimationFrames()
+								self.vtf_frame_limit[property_name] = texture:GetNumAnimationFrames()
 							end
 						end
 					end
@@ -464,8 +464,8 @@ for shader_name, groups in pairs(shader_params.shaders) do
 					if property_name:lower():find("frame") then
 						PART["Set" .. property_name] = function(self, val)
 							self[property_name] = val
-							if self.vtf_frame_limit and self.vtf_frame_limit[group] then
-								self:GetRawMaterial():SetInt(key, math.abs(val)%self.vtf_frame_limit[group])
+							if self.vtf_frame_limit and info.linked and self.vtf_frame_limit[info.linked] then
+								self:GetRawMaterial():SetInt(key, math.abs(val)%self.vtf_frame_limit[info.linked])
 							else
 								self:GetRawMaterial():SetInt(key, val)
 							end

--- a/lua/pac3/core/client/parts/material.lua
+++ b/lua/pac3/core/client/parts/material.lua
@@ -259,15 +259,27 @@ for shader_name, groups in pairs(shader_params.shaders) do
 
 
 	function PART:GetNiceName()
-		local path = self:Getbasetexture()
+		local path = ""
+
+		if shader_name == "refract" then
+			path = self:Getnormalmap()
+		elseif shader_name == "eyerefract" then
+			path = self:Getiris()
+		else
+			path = self:Getbasetexture()
+		end
+
 		path = path:gsub("%%(..)", function(char)
 			local num = tonumber("0x" .. char)
 			if num then
 				return string.char(num)
 			end
 		end)
+
 		local name = ("/".. path):match(".+/(.-)%.") or ("/".. path):match(".+/(.+)")
-		return pac.PrettifyName(name) or "?"
+		local nice_name = (pac.PrettifyName(name) or "no texture") .. " | " .. shader_name
+
+		return nice_name
 	end
 
 	function PART:SetMaterialOverride(num)

--- a/lua/pac3/core/client/parts/material.lua
+++ b/lua/pac3/core/client/parts/material.lua
@@ -511,8 +511,13 @@ for shader_name, groups in pairs(shader_params.shaders) do
 						end
 					else
 						PART["Set" .. property_name] = function(self, val)
+							if type(val) == "Vector" then 
+								val = (val == Vector(1,1,1)) and true or false 
+							end
+	
 							self[property_name] = val
 							local mat = self:GetRawMaterial()
+
 							mat:SetInt(key, val and 1 or 0)
 							if info.recompute then mat:Recompute() end
 						end

--- a/lua/pac3/core/client/parts/material.lua
+++ b/lua/pac3/core/client/parts/material.lua
@@ -82,7 +82,9 @@ for shader_name, groups in pairs(shader_params.shaders) do
 	for group_name, base_group in pairs(shader_params.base) do
 		if groups[group_name] then
 			for k,v in pairs(base_group) do
-				groups[group_name][k] = v
+				if not groups[group_name][k] then
+					groups[group_name][k] = v
+				end
 			end
 		else
 			groups[group_name] = base_group

--- a/lua/pac3/libraries/shader_params.lua
+++ b/lua/pac3/libraries/shader_params.lua
@@ -61,12 +61,6 @@ return {
 					default = true,
 					friendly = "RayTraceSphere",
 				},
-				irisframe = {
-					type = "integer",
-					description = "frame for the iris texture",
-					default = 0,
-					friendly = "IrisFrame",
-				},
 				eyeorigin = {
 					type = "vec3",
 					description = "origin for the eyes",
@@ -78,6 +72,13 @@ return {
 					description = "iris texture",
 					default = "shadertest/BaseTexture",
 					friendly = "Iris",
+				},
+				irisframe = {
+					type = "integer",
+					description = "frame for the iris texture",
+					default = 0,
+					friendly = "IrisFrame",
+					linked = "iris"
 				},
 				dilation = {
 					type = "float",
@@ -216,6 +217,7 @@ return {
 					description = "",
 					default = 0,
 					friendly = "MaskFrame",
+					linked = "sheenmap"
 				},
 				sheenmapmaskdirection = {
 					type = "integer",
@@ -615,6 +617,7 @@ return {
 					friendly = "Frame",
 					default = 0,
 					description = "The frame to start an animated bump map on.",
+					linked = "bumpmap"
 				},
 				bumptransform = {
 					type = "matrix",
@@ -1033,6 +1036,7 @@ return {
 					friendly = "Frame",
 					default = 0,
 					description = "Animation Frame",
+					linked = "basetexture"
 				},
 			},
 			["self illumination"] = {
@@ -1181,14 +1185,15 @@ return {
 				refracttinttextureframe = {
 					type = "integer",
 					friendly = "TintTextureFrame",
-					description = "",
+					description = "Frame to start an animated tint texture on.",
 					default = 0,
+					linked = "refracttinttexture"
 				},
 				refracttint = {
 					type = "color",
 					friendly = "Tint",
 					default = Vector(1, 1, 1),
-					description = "The pattern of refraction is defined by a normal map (DX9+) or DUDV map (DX8-). May be animated.",
+					description = "Tint color of the refraction.",
 				},
 				refractamount = {
 					type = "float",
@@ -1279,13 +1284,25 @@ return {
 					default = 0,
 					friendly = "BumpFrame",
 					description = "The frame to start the first animated bump map on.",
+					linked = "normalmap"
 				},
 				bumpframe2 = {
 					type = "int",
 					default = 0,
 					friendly = "SecondBumpFrame",
 					description = "The frame to start the second animated bump map on.",
-				}
+					linked = "normalmap2"
+				},
+				bumptransform = {
+					type = "matrix",
+					friendly = "Transform",
+					description = "Transform of the first bump map.",
+				},
+				bumptransform2 = {
+					type = "matrix",
+					friendly = "Second Transform",
+					description = "Transform of the second bump map.",
+				},
 			},
 		},
 	},
@@ -1306,6 +1323,7 @@ return {
 				friendly = "Frame",
 				default = 0,
 				description = "Base Texture Animation Frame",
+				linked = "basetexture"
 			},
 		},
 		detail = {
@@ -1325,6 +1343,7 @@ return {
 				friendly = "Frame",
 				default = 0,
 				description = "frame number for $detail",
+				linked = "detail"
 			},
 			detailblendmode = {
 				recompute = true,
@@ -1358,19 +1377,6 @@ return {
 				type = "matrix",
 				friendly = "Transform",
 				description = "$detail texcoord transform",
-			},
-		},
-		["environment map"] = {
-			envmapmasktransform = {
-				type = "matrix",
-				friendly = "MaskTransform",
-				description = "$envmapmask texcoord transform",
-			},
-			envmapmaskframe = {
-				type = "integer",
-				friendly = "MaskFrame",
-				default = 0,
-				description = "",
 			},
 		},
 		["depth blend"] = {
@@ -1469,6 +1475,7 @@ return {
 				friendly = "Frame",
 				default = 0,
 				description = "Animation Frame for $flashlight",
+				linked = "flashlighttexture"
 			},
 			receiveflashlight = {
 				type = "bool",
@@ -1494,6 +1501,11 @@ return {
 			},
 		},
 		["environment map"] = {
+			envmapmasktransform = {
+				type = "matrix",
+				friendly = "MaskTransform",
+				description = "$envmapmask texcoord transform",
+			},
 			envmapsaturation = {
 				type = "float",
 				friendly = "Saturation",
@@ -1511,6 +1523,13 @@ return {
 				friendly = "Mask",
 				description = "envmap mask",
 			},
+			envmapmaskframe = {
+				type = "integer",
+				friendly = "MaskFrame",
+				default = 0,
+				description = "Frame of the animated mask.",
+				linked = "envmapmask"
+			},
 			envmapcameraspace = {
 				is_flag = true,
 				type = "integer",
@@ -1524,6 +1543,13 @@ return {
 				description = "envmap. won't work if hdr is enabled",
 				default = "",
 				partial_hdr = true
+			},
+			envmapframe = {
+				type = "integer",
+				friendly = "Frame",
+				default = 0,
+				description = "envmap frame number",
+				linked = "envmap"
 			},
 			envmapmode = {
 				is_flag = true,
@@ -1544,12 +1570,6 @@ return {
 				friendly = "Sphere",
 				default = false,
 				description = "flag",
-			},
-			envmapframe = {
-				type = "integer",
-				friendly = "Frame",
-				default = 0,
-				description = "envmap frame number",
 			},
 			normalmapalphaenvmapmask = {
 				is_flag = true,

--- a/lua/pac3/libraries/shader_params.lua
+++ b/lua/pac3/libraries/shader_params.lua
@@ -1259,11 +1259,6 @@ return {
 				},
 			},
 			normal = {
-				normalmap2 = {
-					type = "texture",
-					friendly = "NormalMap2",
-					description = "If a second normal map is specified, it will be blended with the first one.",
-				},
 				dudvmap = {
 					type = "texture",
 					friendly = "DudvMap",
@@ -1272,7 +1267,25 @@ return {
 				normalmap = {
 					type = "texture",
 					friendly = "NormalMap",
+					description = "The pattern of refraction is defined by a normal map (DX9+) or DUDV map (DX8-). May be animated.",
 				},
+				normalmap2 = {
+					type = "texture",
+					friendly = "SecondNormalMap",
+					description = "If a second normal map is specified, it will be blended with the first one.",
+				},
+				bumpframe = {
+					type = "int",
+					default = 0,
+					friendly = "BumpFrame",
+					description = "The frame to start the first animated bump map on.",
+				},
+				bumpframe2 = {
+					type = "int",
+					default = 0,
+					friendly = "SecondBumpFrame",
+					description = "The frame to start the second animated bump map on.",
+				}
 			},
 		},
 	},

--- a/lua/pac3/libraries/shader_params.lua
+++ b/lua/pac3/libraries/shader_params.lua
@@ -1199,8 +1199,8 @@ return {
 			},
 			generic = {
 				vertexcolormodulate = {
-					type = "color",
-					default = Vector(0, 0, 0),
+					type = "bool",
+					default = false,
 					friendly = "VertexColorModulate",
 					recompute = true,
 				},

--- a/lua/pac3/libraries/shader_params.lua
+++ b/lua/pac3/libraries/shader_params.lua
@@ -57,7 +57,7 @@ return {
 				spheretexkillcombo = {
 					type = "bool",
 					description = "Requires $raytracesphere 1. Causes pixels which don't hit the raytraced sphere to be transparent",
-					default = true,
+					default = false,
 					friendly = "SphereTexkillCombo",
 				},
 				eyeorigin = {
@@ -121,13 +121,6 @@ return {
 					default = 0.5,
 					friendly = "Glossiness",
 				},
-				envmap = {
-					type = "texture",
-					friendly = "Envmap",
-					description = "Enables cubemap reflections.",
-					default = "",
-					partial_hdr = true
-				},
 			},
 			cloak = {
 				cloakpassenabled = {
@@ -155,6 +148,15 @@ return {
 					description = "How strong the refraction effect should be when the material is partially cloaked (default = 2).",
 				},
 			},
+			["environment map"] = {
+				envmap = {
+					type = "texture",
+					friendly = "Envmap",
+					description = "Enables cubemap reflections.",
+					default = "Engine/eye-reflection-cubemap-",
+					partial_hdr = true
+				},
+			}
 		},
 		vertexlitgeneric = {
 			wrinkle = {
@@ -1167,6 +1169,13 @@ return {
 			},
 		},
 		refract = {
+			["base texture"] = {
+				basetexture = {
+					type = "texture",
+					description = "Use a texture instead of rendering the view for the source of the distorted pixels.",
+					default = "",
+				},
+			},
 			["local"] = {
 				localrefract = {
 					type = "bool",
@@ -1216,7 +1225,7 @@ return {
 				refractamount = {
 					type = "float",
 					friendly = "RefractAmount",
-					default = 0,
+					default = 0.5,
 					description = "How strong the refraction effect should be when the material is partially cloaked (default = 2).",
 				},
 			},
@@ -1286,11 +1295,13 @@ return {
 					type = "texture",
 					friendly = "DudvMap",
 					description = "The pattern of refraction is defined by a normal map (DX9+) or DUDV map (DX8-). May be animated.",
+					default = "dev/water_dudv",
 				},
 				normalmap = {
 					type = "texture",
 					friendly = "NormalMap",
 					description = "The pattern of refraction is defined by a normal map (DX9+) or DUDV map (DX8-). May be animated.",
+					default = "dev/water_normal",
 				},
 				normalmap2 = {
 					type = "texture",

--- a/lua/pac3/libraries/shader_params.lua
+++ b/lua/pac3/libraries/shader_params.lua
@@ -22,24 +22,17 @@ return {
 				corneatexture = {
 					type = "texture",
 					description = "cornea texture",
-					default = "shadertest/BaseTexture",
+					default = "Engine/eye-cornea",
 				},
 				ambientoccltexture = {
 					type = "texture",
 					description = "reflection texture",
-					default = "shadertest/BaseTexture",
-				},
-				envmap = {
-					type = "texture",
-					friendly = "Envmap",
-					description = "envmap. won't work if hdr is enabled",
-					default = "",
-					partial_hdr = true
+					default = "Engine/eye-extra",
 				},
 				ambientocclcolor = {
 					type = "vec3",
 					description = "Ambient occlusion color",
-					default = Vector(1,1,1),
+					default = Vector(0.33,0.33,0.33),
 				},
 			},
 			eye = {
@@ -51,15 +44,21 @@ return {
 				},
 				eyeballradius = {
 					type = "float",
-					description = "Eyeball radius for ray casting",
-					default = 0,
+					description = "Requires $raytracesphere 1. Radius of the eyeball. Should be the diameter of the eyeball divided by 2.",
+					default = 0.5,
 					friendly = "EyeballRadius",
 				},
 				raytracesphere = {
 					type = "bool",
-					description = "Raytrace sphere",
+					description = "Enables sphere raytracing. Each pixel is raytraced to allow sharper angles to look more accurate.",
 					default = true,
 					friendly = "RayTraceSphere",
+				},
+				spheretexkillcombo = {
+					type = "bool",
+					description = "Requires $raytracesphere 1. Causes pixels which don't hit the raytraced sphere to be transparent",
+					default = true,
+					friendly = "SphereTexkillCombo",
 				},
 				eyeorigin = {
 					type = "vec3",
@@ -70,7 +69,7 @@ return {
 				iris = {
 					type = "texture",
 					description = "iris texture",
-					default = "shadertest/BaseTexture",
+					default = "engine/eye-iris-green",
 					friendly = "Iris",
 				},
 				irisframe = {
@@ -83,7 +82,7 @@ return {
 				dilation = {
 					type = "float",
 					description = "Pupil dilation (0 is none, 1 is maximal)",
-					default = 0,
+					default = 0.5,
 					friendly = "Dilation",
 				},
 				irisu = {
@@ -101,7 +100,7 @@ return {
 				parallaxstrength = {
 					type = "float",
 					description = "Parallax strength",
-					default = 1,
+					default = 0.25,
 					friendly = "ParallaxStrength",
 				},
 				corneabumpstrength = {
@@ -109,6 +108,25 @@ return {
 					description = "Cornea strength",
 					default = 1,
 					friendly = "CorneaBumpStrength",
+				},
+				halflambert = {
+					type = "bool",
+					description = "Enables half-lambertian lighting.",
+					default = 1,
+					friendly = "HalfLambert",
+				},
+				glossiness = {
+					type = "float",
+					description = "The opacity of the cubemap reflection.",
+					default = 0.5,
+					friendly = "Glossiness",
+				},
+				envmap = {
+					type = "texture",
+					friendly = "Envmap",
+					description = "Enables cubemap reflections.",
+					default = "",
+					partial_hdr = true
 				},
 			},
 			cloak = {


### PR DESCRIPTION
Setting different defaults for each shader now works properly.
The fixed 'load vmt' makes it really easy to replace/edit existing in-game materials.

New defaults create proper materials instead of the old empty/error ones:
![refract](https://user-images.githubusercontent.com/12747052/148301870-aa5de956-23d7-4694-ad18-116e371ceb75.png)
![eye_refract](https://user-images.githubusercontent.com/12747052/148303610-aa41a8b2-b195-414f-9bfe-e7dc472da7ba.png)

The new/fixed params allow users to create materials such as this one:
![ezgif-3-42f01f3ede](https://user-images.githubusercontent.com/12747052/148307237-56f270b3-bb74-4ace-8746-45c6c895ce8b.gif)

