### PR TITLE
Fixes for the 'spawn as props' tool 

### DIFF
--- a/lua/pac3/extra/client/contraption.lua
+++ b/lua/pac3/extra/client/contraption.lua
@@ -19,7 +19,7 @@ function pacx.PartToContraptionData(part, tbl)
 		if part.ProperColorRange then
 			data.clr = Color(color.r * 255, color.g * 255, color.b * 255, alpha * 255)
 		else
-			data.clr = Color(color.r, color.g, color.b, alpha)
+			data.clr = Color(color.r, color.g, color.b, alpha * 255)
 		end
 
 		data.ang = part:GetOwner():GetAngles()

--- a/lua/pac3/extra/client/contraption.lua
+++ b/lua/pac3/extra/client/contraption.lua
@@ -13,9 +13,15 @@ function pacx.PartToContraptionData(part, tbl)
 	if part.is_model_part then
 		local data = {}
 
-		local c = part:GetColor()
+		local color = part:GetColor()
+		local alpha = part:GetAlpha()
 
-		data.clr = {c.r, c.g, c.b, part:GetAlpha() * 255}
+		if part.ProperColorRange then
+			data.clr = Color(color.r * 255, color.g * 255, color.b * 255, alpha * 255)
+		else
+			data.clr = Color(color.r, color.g, color.b, alpha)
+		end
+
 		data.ang = part:GetOwner():GetAngles()
 		data.pos = part:GetOwner():GetPos()
 		data.mat = part:GetMaterial()

--- a/lua/pac3/extra/server/contraption.lua
+++ b/lua/pac3/extra/server/contraption.lua
@@ -30,6 +30,7 @@ local function spawn(val,ply)
 	ent:Spawn()
 	ent:SetHealth(9999999)
 	ent:SetColor(val.clr)
+	ent:SetRenderMode( RENDERMODE_TRANSCOLOR )
 
 	hook.Run("PlayerSpawnedProp", ply, model, ent)
 

--- a/lua/pac3/extra/server/contraption.lua
+++ b/lua/pac3/extra/server/contraption.lua
@@ -100,7 +100,7 @@ pace.PCallNetReceive(net.Receive, "pac_to_contraption", function(len, ply)
 	if count > max then
 		net.Start("pac_submit_acknowledged")
 			net.WriteBool(false)
-			net.WriteString("You can only spawn ", max, " props at a time!")
+			net.WriteString("You can only spawn " .. max .. " props at a time!")
 		net.Send(ply)
 
 		pac.Message(ply, " might have tried to crash the server by attempting to spawn ", count, " entities with the contraption system!")


### PR DESCRIPTION
Props should now spawn properly, have correct colors and working transparency. Related to #1078 
![image](https://user-images.githubusercontent.com/12747052/152890748-8ada30e3-5fd0-4c25-9fbc-e53c822800f1.png)
