### PR TITLE
Micro Optimize object type checking

### DIFF
--- a/lua/autorun/pac_restart.lua
+++ b/lua/autorun/pac_restart.lua
@@ -31,7 +31,7 @@ function _G.pac_ReloadParts()
 					local str = file.Read("addons/" .. dir .. "/lua/" .. new_path, "MOD")
 					if str then
 						local func = CompileString(str, "addons/" .. dir .. "/lua/" .. new_path)
-						if type(func) == "function" then
+						if isfunction(func) then
 							local res = {pcall(func, ...)}
 
 							if res[1] then
@@ -170,7 +170,7 @@ function _G.pac_Restart()
 						local str = file.Read("addons/" .. dir .. "/lua/" .. new_path, "MOD")
 						if str then
 							local func = CompileString(str, "addons/" .. dir .. "/lua/" .. new_path)
-							if type(func) == "function" then
+							if isfunction(func) then
 								local res = {pcall(func, ...)}
 
 								if res[1] then

--- a/lua/pac3/core/client/class.lua
+++ b/lua/pac3/core/client/class.lua
@@ -91,10 +91,10 @@ do
 		pac.VariableOrder[tbl.ClassName] = pac.VariableOrder[tbl.ClassName] or {}
 		insert_key(pac.VariableOrder[tbl.ClassName], key)
 
-		if type(def) == "number" then
+		if isnumber(def) then
 			tbl["Set" .. key] = tbl["Set" .. key] or function(self, var) self[key] = tonumber(var) end
 			tbl["Get" .. key] = tbl["Get" .. key] or function(self) return tonumber(self[key]) end
-		elseif type(def) == "string" then
+		elseif isstring(def) then
 			tbl["Set" .. key] = tbl["Set" .. key] or function(self, var) self[key] = tostring(var) end
 			tbl["Get" .. key] = tbl["Get" .. key] or function(self) return tostring(self[key]) end
 		else
@@ -135,7 +135,7 @@ do
 				return
 			end
 
-			if type(uid) == "table" then
+			if istable(uid) then
 				uid = uid.UniqueID
 			end
 

--- a/lua/pac3/core/client/part_pool.lua
+++ b/lua/pac3/core/client/part_pool.lua
@@ -440,7 +440,7 @@ function pac.UpdatePartsWithMetatable(META)
 			for k, v in pairs(META) do
 				-- update part functions only
 				-- updating variables might mess things up
-				if type(v) == "function" then
+				if isfunction(v) then
 					part[k] = v
 				end
 			end

--- a/lua/pac3/core/client/parts/beam.lua
+++ b/lua/pac3/core/client/parts/beam.lua
@@ -182,7 +182,7 @@ function PART:SetMaterial(var)
 	self.Material = var
 
 	if not pac.Handleurltex(self, var) then
-		if type(var) == "string" then
+		if isstring(var) then
 			self.Materialm = pac.Material(var, self)
 			self:FixMaterial()
 			self:CallRecursive("OnMaterialChanged")

--- a/lua/pac3/core/client/parts/custom_animation.lua
+++ b/lua/pac3/core/client/parts/custom_animation.lua
@@ -116,7 +116,7 @@ function PART:SetData(str)
 		local tbl = util.JSONToTable(str)
 		if tbl then
 
-			if type(tbl.Type) == "number" then
+			if isnumber(tbl.Type) then
 				animations.ConvertOldData(tbl)
 				self:SetAnimationType(tbl.Type)
 				self:SetInterpolation(tbl.Interpolation)

--- a/lua/pac3/core/client/parts/event.lua
+++ b/lua/pac3/core/client/parts/event.lua
@@ -126,7 +126,7 @@ end
 local movetypes = {}
 
 for k,v in pairs(_G) do
-	if type(k) == "string" and type(v) == "number" and k:sub(0,9) == "MOVETYPE_" then
+	if isstring(k) and isnumber(v) and k:sub(0,9) == "MOVETYPE_" then
 		movetypes[v] = k:sub(10):lower()
 	end
 end
@@ -1122,7 +1122,7 @@ do
 	local enums = {}
 	local enums2 = {}
 	for key, val in pairs(_G) do
-		if type(key) == "string" and type(val) == "number" then
+		if isstring(key) and isnumber(val) then
 			if key:sub(0,4) == "KEY_" and not key:find("_LAST$") and not key:find("_FIRST$")  and not key:find("_COUNT$")  then
 				enums[val] = key:sub(5):lower()
 				enums2[enums[val]] = val
@@ -1299,7 +1299,7 @@ do
 			local newObj = pac.CreateEvent(self:GetClass())
 
 			for k, v in pairs(self) do
-				if type(v) ~= 'table' then
+				if not istable(v) then
 					newObj[k] = v
 				else
 					newObj[k] = table.Copy(v)
@@ -1774,7 +1774,7 @@ do
 	local enums = {}
 
 	for key, val in pairs(_G) do
-		if type(key) == "string" and key:find("PLAYERANIMEVENT_", nil, true) then
+		if isstring(key) and key:find("PLAYERANIMEVENT_", nil, true) then
 			enums[val] = key:gsub("PLAYERANIMEVENT_", ""):gsub("_", " "):lower()
 		end
 	end

--- a/lua/pac3/core/client/parts/legacy/bone.lua
+++ b/lua/pac3/core/client/parts/legacy/bone.lua
@@ -245,7 +245,7 @@ function PART:OnBuildBonePositions()
 		end
 	end
 
-	owner:ManipulateBoneJiggle(index, type(self.Jiggle) == "number" and self.Jiggle or (self.Jiggle and 1 or 0)) -- afaik anything but 1 is not doing anything at all
+	owner:ManipulateBoneJiggle(index, isnumber(self.Jiggle) and self.Jiggle or (self.Jiggle and 1 or 0)) -- afaik anything but 1 is not doing anything at all
 
 	local scale
 

--- a/lua/pac3/core/client/parts/legacy/bone2.lua
+++ b/lua/pac3/core/client/parts/legacy/bone2.lua
@@ -254,7 +254,7 @@ function PART:OnBuildBonePositions()
 		end
 	end
 
-	owner:ManipulateBoneJiggle(index, type(self.Jiggle) == "number" and self.Jiggle or (self.Jiggle and 1 or 0)) -- afaik anything but 1 is not doing anything at all
+	owner:ManipulateBoneJiggle(index, isnumber(self.Jiggle) and self.Jiggle or (self.Jiggle and 1 or 0)) -- afaik anything but 1 is not doing anything at all
 
 	local scale
 

--- a/lua/pac3/core/client/parts/legacy/material.lua
+++ b/lua/pac3/core/client/parts/legacy/material.lua
@@ -143,7 +143,7 @@ local function setup(PART)
 
 				local found
 
-				if type(info.pattern) == "table" then
+				if istable(info.pattern) then
 					for k,v in pairs(info.pattern) do
 						if name:lower():find(v) then
 							found = true
@@ -170,7 +170,7 @@ local function setup(PART)
 
 				do
 					local extra
-					if type(T) == "table" then
+					if istable(T) then
 						extra = T.extra
 						T = T.type
 					end

--- a/lua/pac3/core/client/parts/legacy/sound.lua
+++ b/lua/pac3/core/client/parts/legacy/sound.lua
@@ -119,7 +119,7 @@ local function fix(snd)
 end
 
 function PART:SetSound(str)
-	if type(str) ~= "string" then self.Sound = "" return end
+	if not isstring(str) then self.Sound = "" return end
 
 	if bad[str:sub(1,1)] or bad[str:sub(2,2)] then
 		str = fix(str)

--- a/lua/pac3/core/client/parts/legacy/trail.lua
+++ b/lua/pac3/core/client/parts/legacy/trail.lua
@@ -101,7 +101,7 @@ function PART:SetMaterial(var)
 	var = var or ""
 
 	if not pac.Handleurltex(self, var) then
-		if type(var) == "string" then
+		if isstring(var) then
 			self.Materialm = pac.Material(var, self)
 			self:CallRecursive("OnMaterialChanged")
 		elseif type(var) == "IMaterial" then

--- a/lua/pac3/core/client/parts/material.lua
+++ b/lua/pac3/core/client/parts/material.lua
@@ -37,7 +37,7 @@ local material_flags = {
 }
 
 local function TableToFlags(flags, valid_flags)
-	if type(flags) == "string" then
+	if isstring(flags) then
 		flags = {flags}
 	end
 
@@ -149,14 +149,13 @@ for shader_name, groups in pairs(shader_params.shaders) do
 
 			local func = self["Set" .. k]
 			if func then
-				local t = type(v)
 				local info = PART.ShaderParams[k]
 
-				if type(v) == "string" then
+				if isstring(v) then
 					if v:find("[", nil, true) then
 						v = Vector(v:gsub("[%[%]]", ""):gsub("%s+", " "):Trim())
 
-						if type(info.default) == "number" then
+						if isnumber(info.default) then
 							v = v.x
 						end
 					elseif v:find("{", nil, true) then
@@ -168,7 +167,7 @@ for shader_name, groups in pairs(shader_params.shaders) do
 					end
 				end
 
-				if type(v) == "number" then
+				if isnumber(v) then
 					if info.type == "bool" or info.is_flag then
 						v = v == 1
 					end
@@ -477,7 +476,7 @@ for shader_name, groups in pairs(shader_params.shaders) do
 				local flag_key = key
 				local key = "$" .. key
 
-				if type(info.default) == "number" then
+				if isnumber(info.default) then
 					PART["Set" .. property_name] = function(self, val)
 						self[property_name] = val
 						local mat = self:GetRawMaterial()
@@ -496,7 +495,7 @@ for shader_name, groups in pairs(shader_params.shaders) do
 							end
 						end
 					end
-				elseif type(info.default) == "boolean" then
+				elseif isbool(info.default) then
 					if info.is_flag then
 						PART["Set" .. property_name] = function(self, val)
 							self[property_name] = val
@@ -511,10 +510,10 @@ for shader_name, groups in pairs(shader_params.shaders) do
 						end
 					else
 						PART["Set" .. property_name] = function(self, val)
-							if type(val) == "Vector" then 
-								val = (val == Vector(1,1,1)) and true or false 
+							if isvector(val) then
+								val = (val == Vector(1,1,1)) and true or false
 							end
-	
+
 							self[property_name] = val
 							local mat = self:GetRawMaterial()
 
@@ -522,9 +521,9 @@ for shader_name, groups in pairs(shader_params.shaders) do
 							if info.recompute then mat:Recompute() end
 						end
 					end
-				elseif type(info.default) == "Vector" or info.type == "vec3" or info.type == "vec2" then
+				elseif isvector(info.default) or info.type == "vec3" or info.type == "vec2" then
 					PART["Set" .. property_name] = function(self, val)
-						if type(val) == "string" then val = Vector() end
+						if isstring(val) then val = Vector() end
 						self[property_name] = val
 						local mat = self:GetRawMaterial()
 						mat:SetVector(key, val)
@@ -535,13 +534,13 @@ for shader_name, groups in pairs(shader_params.shaders) do
 					PART["Set" .. property_name] = function(self, val)
 
 						local x,y,z,w
-						if type(val) == "string" then
+						if isstring(val) then
 							x,y,z,w = unpack(val:Split(" "))
 							x = tonumber(x) or 0
 							y = tonumber(y) or 0
 							z = tonumber(z) or 0
 							w = tonumber(w) or 0
-						elseif type(val) == "Vector" then
+						elseif isvector(val) then
 							x,y,z = val.x, val.y, val.z
 							w = 0
 						else

--- a/lua/pac3/core/client/parts/proxy.lua
+++ b/lua/pac3/core/client/parts/proxy.lua
@@ -914,9 +914,9 @@ function PART:OnThink()
 			return
 		end
 
-		if x and type(x) ~= "number" then x = 0 end
-		if y and type(y) ~= "number" then y = 0 end
-		if z and type(z) ~= "number" then z = 0 end
+		if x and not isnumber(x) then x = 0 end
+		if y and not isnumber(y) then y = 0 end
+		if z and not isnumber(y) then z = 0 end
 
 		if self.Additive then
 			if x then
@@ -970,7 +970,7 @@ function PART:OnThink()
 		if post_function and input_function then
 			local input_number = input_function(self)
 
-			if type(input_number) ~= "number" then
+			if not isnumber(input_number) then
 				error("proxy function " .. self.Input .. " does not return a number!")
 			end
 

--- a/lua/pac3/core/client/parts/script.lua
+++ b/lua/pac3/core/client/parts/script.lua
@@ -212,7 +212,7 @@ function PART:CompileCode()
 
 	local func = CompileString(code, "SCRIPT_ENV", false)
 
-	if type(func) == "string" then
+	if isstring(func) then
 		return false, func
 	end
 
@@ -362,7 +362,7 @@ function PART:CompileCode()
 		for key, val in pairs(tbl) do
 			self.valid_functions[key] = val
 
-			if type(val) == "table" then
+			if istable(val) then
 				scan(val)
 			end
 		end

--- a/lua/pac3/core/client/parts/sprite.lua
+++ b/lua/pac3/core/client/parts/sprite.lua
@@ -88,7 +88,7 @@ function PART:SetMaterial(var)
 	var = var or ""
 
 	if not pac.Handleurltex(self, var, nil, "UnlitGeneric", {["$translucent"] = "1"}) then
-		if type(var) == "string" then
+		if isstring(var) then
 			self.Materialm = pac.Material(var, self)
 			self:CallRecursive("OnMaterialChanged")
 		elseif type(var) == "IMaterial" then

--- a/lua/pac3/core/client/parts/trail.lua
+++ b/lua/pac3/core/client/parts/trail.lua
@@ -133,7 +133,7 @@ function PART:SetMaterial(var)
 		self.Materialm = mat
 		self:MakeMaterialUnlit()
 	end) then
-		if type(var) == "string" then
+		if isstring(var) then
 			self.Materialm = pac.Material(var, self)
 			self:CallRecursive("OnMaterialChanged")
 		elseif type(var) == "IMaterial" then

--- a/lua/pac3/core/client/tests/property_fuzz.lua
+++ b/lua/pac3/core/client/tests/property_fuzz.lua
@@ -56,15 +56,15 @@ function test.Run(done)
 						val = part:CreatePart(table.Random(classes))
 					end
 					val = val:GetUniqueID()
-				elseif type(val) == "number" then
+				elseif isnumber(val) then
 					val = math.Rand(-1000, 100)
-				elseif type(val) == "Vector" then
+				elseif isvector(val) then
 					val = VectorRand()*1000
-				elseif type(val) == "Angle" then
+				elseif isangle(val) then
 					val = Angle(math.Rand(0, 360), math.Rand(0, 360), math.Rand(0, 360))
-				elseif type(val) == "boolean" then
+				elseif isbool(val) then
 					val = math.random() > 0.5
-				elseif type(val) == "string" then
+				elseif isstring(val) then
 
 
 

--- a/lua/pac3/core/shared/entity_mutators/model.lua
+++ b/lua/pac3/core/shared/entity_mutators/model.lua
@@ -4,7 +4,7 @@ MUTATOR.ClassName = "model"
 MUTATOR.UpdateRate = 0.25
 
 function MUTATOR:WriteArguments(path)
-	assert(type(path) == "string", "path must be a string")
+	assert(isstring(path), "path must be a string")
 
 	net.WriteString(path)
 end

--- a/lua/pac3/editor/client/about.lua
+++ b/lua/pac3/editor/client/about.lua
@@ -202,7 +202,7 @@ end
 surface.CreateFont("pace_about_1", {font = "Roboto Bold", size = 512, weight = 800, additive = false, antialias = true})
 
 local credits = {}
-local A = function(str, size, ...) table.insert(credits, {str, size or type(str) == "string" and 1 or nil, ...}) end
+local A = function(str, size, ...) table.insert(credits, {str, size or isstring(str) and 1 or nil, ...}) end
 
 local cast = {
 	"morshmellow",

--- a/lua/pac3/editor/client/asset_browser.lua
+++ b/lua/pac3/editor/client/asset_browser.lua
@@ -60,7 +60,7 @@ local function install_click(icon, path, pattern, on_menu, pathid)
 			local menu = DermaMenu()
 			menu:AddOption(L"copy path", function()
 				if pattern then
-					for _, pattern in ipairs(type(pattern) == "string" and {pattern} or pattern) do
+					for _, pattern in ipairs(isstring(pattern) and {pattern} or pattern) do
 						local test = path:match(pattern)
 						if test then
 							path = test
@@ -946,7 +946,7 @@ function pace.AssetBrowser(callback, browse_types_str, part_key)
 								if object.type == "model" then
 									node.propPanel:Add(create_model_icon(object.model))
 								elseif object.type == "header" then
-									if not object.text or type(object.text) ~= "string" then return end
+									if not object.text or not isstring(object.text) then return end
 
 									local label = vgui.Create("ContentHeader", node.propPanel)
 									label:SetText(object.text)

--- a/lua/pac3/editor/client/init.lua
+++ b/lua/pac3/editor/client/init.lua
@@ -232,7 +232,7 @@ do -- forcing hooks
 				pace.OldHooks[event] = table.Copy(hooks)
 
 				for name in pairs(hooks) do
-					if type(name) == "string" and name:sub(1, 4) ~= "pace_" then
+					if isstring(name) and name:sub(1, 4) ~= "pace_" then
 						hook.Remove(event, name)
 					end
 				end
@@ -246,7 +246,7 @@ do -- forcing hooks
 		if pace.OldHooks then
 			for event, hooks in pairs(pace.OldHooks) do
 				for name, func in pairs(hooks) do
-					if type(name) == "string" and name:sub(1, 4) ~= "pace_" then
+					if isstring(name) and name:sub(1, 4) ~= "pace_" then
 						hook.Add(event, name, func)
 					end
 				end

--- a/lua/pac3/editor/client/panels/extra_properties.lua
+++ b/lua/pac3/editor/client/panels/extra_properties.lua
@@ -165,7 +165,7 @@ do -- part
 			local pnl = vgui.Create("SpawnIcon", self)
 			pnl:SetModel(part:GetOwner():GetModel() or "")
 			self.Icon = pnl
-		elseif type(part.Icon) == "string" then
+		elseif isstring(part.Icon) then
 			local pnl = vgui.Create("DImage", self)
 			pnl:SetImage(part.Icon)
 			self.Icon = pnl

--- a/lua/pac3/editor/client/panels/lua_editor.lua
+++ b/lua/pac3/editor/client/panels/lua_editor.lua
@@ -253,11 +253,11 @@ function PANEL:SyntaxColorLine(row)
 
 				token = "expression"
 
-			elseif(self:CheckGlobal(sstr)  and  (type(self:CheckGlobal(sstr)) == "function" or self:CheckGlobal(sstr) == "f"
-			or self:CheckGlobal(sstr) == "e" or self:CheckGlobal(sstr) == "m" or type(self:CheckGlobal(sstr)) == "table")
+			elseif(self:CheckGlobal(sstr)  and  (isfunction(self:CheckGlobal(sstr)) or self:CheckGlobal(sstr) == "f"
+			or self:CheckGlobal(sstr) == "e" or self:CheckGlobal(sstr) == "m" or istable(self:CheckGlobal(sstr)))
 			or (lasttable  and  lasttable[sstr])) then -- Could be better code, but what the hell; it works
 
-				if(type(self:CheckGlobal(sstr)) == "table") then
+				if(istable(self:CheckGlobal(sstr))) then
 					lasttable = self:CheckGlobal(sstr);
 				end
 
@@ -275,7 +275,7 @@ function PANEL:SyntaxColorLine(row)
 				token = "none"
 
 			end
-		elseif(self.char == "\"") then -- TODO: Fix multiline strings, and add support for [[stuff]] not 
+		elseif(self.char == "\"") then -- TODO: Fix multiline strings, and add support for [[stuff]] not
 
 			self:NextChar()
 			while self.char and self.char ~= "\"" do

--- a/lua/pac3/editor/client/panels/properties.lua
+++ b/lua/pac3/editor/client/panels/properties.lua
@@ -415,7 +415,7 @@ do -- list
 		pnl.alt_line = #self.List%2 == 1
 		btn.alt_line = pnl.alt_line
 
-		if type(var) == "Panel" then
+		if ispanel(var) then
 			pnl:SetContent(var)
 		end
 
@@ -550,7 +550,7 @@ do -- list
 							function()
 								local tbl
 
-								if type(prop.udata.enums) == "function" then
+								if isfunction(prop.udata.enums) then
 									if pace.current_part:IsValid() then
 										tbl = prop.udata.enums(pace.current_part)
 									end
@@ -562,11 +562,11 @@ do -- list
 
 								if tbl then
 									for k, v in pairs(tbl) do
-										if type(v) ~= "string" then
+										if not isstring(v) then
 											v = k
 										end
 
-										if type(k) ~= "string" then
+										if not isstring(v) then
 											k = v
 										end
 
@@ -759,7 +759,7 @@ do -- base editable
 		if self.editing then return end
 
 		local value = skip_encode and var or self:Encode(var)
-		if type(value) == "number" then
+		if isnumber(value) then
 			-- visually round numbers so 0.6 doesn't show up as 0.600000000001231231 on wear
 			value = math.Round(value, 7)
 		end
@@ -1122,11 +1122,11 @@ do -- vector
 			end):SetImage(pace.MiscIcons.copy)
 			menu:AddOption(L"paste", function()
 				local val = pac.CopyValue(pace.clipboard)
-				if _G.type(val) == "number" then
+				if isnumber(val) then
 					val = ctor(val, val, val)
-				elseif _G.type(val) == "Vector" and type == "angle" then
+				elseif isvector(val) and type == "angle" then
 					val = ctor(val.x, val.y, val.z)
-				elseif _G.type(val) == "Angle" and type == "vector" then
+				elseif isangle(val) and type == "vector" then
 					val = ctor(val.p, val.y, val.r)
 				end
 

--- a/lua/pac3/editor/client/panels/tree.lua
+++ b/lua/pac3/editor/client/panels/tree.lua
@@ -424,7 +424,7 @@ function PANEL:PopulateParts(node, parts, children)
 				part:GetOwner():IsValid()
 			then
 				part_node:SetModel(part:GetOwner():GetModel(), part.Icon)
-			elseif type(part.Icon) == "string" then
+			elseif isstring(part.Icon) then
 				part_node.Icon:SetImage(part.Icon)
 			end
 

--- a/lua/pac3/editor/client/parts.lua
+++ b/lua/pac3/editor/client/parts.lua
@@ -180,7 +180,7 @@ function pace.OnVariableChanged(obj, key, val, not_from_editor)
 				pace.RemovePartOnServer(obj:GetUniqueID(), true, true)
 			end
 			node:SetText(val)
-		elseif key == "Model" and val and val ~= "" and type(val) == "string" then
+		elseif key == "Model" and val and val ~= "" and isstring(val) then
 			node:SetModel(val)
 		elseif key == "Parent" then
 			local tree = obj.pace_tree_node
@@ -296,7 +296,7 @@ do -- menu
 			for _, part in pairs(pace.GetRegisteredParts()) do
 				local group = part.Group or part.Groups or "other"
 
-				if type(group) == "string" then
+				if isstring(group) then
 					group = {group}
 				end
 

--- a/lua/pac3/editor/client/show_outfit_on_use.lua
+++ b/lua/pac3/editor/client/show_outfit_on_use.lua
@@ -91,9 +91,8 @@ timer.Create('pac3_transmissions_ttl', 1, 0, function()
 end)
 
 function pace.HandleOnUseReceivedData(data)
-	local validTransmission = type(data.partID) == 'number' and
-		type(data.totalParts) == 'number' and
-		type(data.transmissionID) == 'number'
+	local validTransmission = isnumber(data.partID) and
+		isnumber(data.totalParts) and isnumber(data.transmissionID)
 
 	if not data.owner.pac_onuse_only then
 		data.owner.pac_onuse_only = true
@@ -159,7 +158,7 @@ function pace.HandleOnUseReceivedData(data)
 		for i, part in ipairs(trData.list) do
 			local func = pace.HandleReceiveData(part)
 
-			if type(func) == 'function' then
+			if isfunction(func) then
 				table.insert(funcs, func)
 			end
 		end

--- a/lua/pac3/editor/client/tools.lua
+++ b/lua/pac3/editor/client/tools.lua
@@ -400,11 +400,11 @@ pace.AddTool(L"round numbers", function(part)
 		for _, key in pairs(part:GetStorableVars()) do
 			local val = part["Get" .. key](part)
 
-			if type(val) == "number" then
+			if isnumber(val) then
 				part["Set" .. key](part, round_pretty(val))
-			elseif type(val) == "Vector" then
+			elseif isvector(val) then
 				part["Set" .. key](part, Vector(round_pretty(val.x), round_pretty(val.y), round_pretty(val.z)))
-			elseif type(val) == "Angle" then
+			elseif isangle(val) then
 				part["Set" .. key](part, Angle(round_pretty(val.p), round_pretty(val.y), round_pretty(val.r)))
 			end
 		end

--- a/lua/pac3/editor/server/bans.lua
+++ b/lua/pac3/editor/server/bans.lua
@@ -9,7 +9,7 @@ local function get_bans()
 
 	do -- check if this needs to be rebuilt
 		local k,v = next(bans)
-		if type(v) == "string" then
+		if isstring(v) then
 			local temp = {}
 
 			for k,v in pairs(bans) do

--- a/lua/pac3/editor/server/wear.lua
+++ b/lua/pac3/editor/server/wear.lua
@@ -51,13 +51,13 @@ local function translate_old_dupe(tableIn, target)
 	for key, value2 in pairs(tableIn) do
 		local value
 
-		if type(value2) == 'table' then
+		if istable(value2) then
 			value = translate_old_dupe(value2, {})
 		else
 			value = value2
 		end
 
-		if type(key) == 'number' and key > 10000 then
+		if isnumber(key) and key > 10000 then
 			local str = uid2key[key] or key
 			target[str] = value
 		else
@@ -86,7 +86,7 @@ duplicator.RegisterEntityModifier("pac_config", function(ply, ent, parts)
 	-- give source engine time
 	timer.Simple(0, function()
 		for uid, data in pairs(parts) do
-			if type(data.part) == "table" then
+			if istable(data.part) then
 				make_copy(data.part, id)
 
 				data.part.self.Name = tostring(ent)
@@ -109,7 +109,7 @@ duplicator.RegisterEntityModifier("pac_config", function(ply, ent, parts)
 end)
 
 function pace.SubmitPart(data, filter)
-	if type(data.part) == "table" then
+	if istable(data.part) then
 		if last_frame == frame_number then
 			table.insert(pace.StreamQueue, {data, filter})
 			pace.dprint("queuing part %q from %s", data.part.self.Name, tostring(data.owner))
@@ -120,7 +120,7 @@ function pace.SubmitPart(data, filter)
 	-- last arg "true" is pac3 only in case you need to do your checking differnetly from pac2
 	local allowed, reason = hook.Run("PrePACConfigApply", data.owner, data, true)
 
-	if type(data.part) == "table" then
+	if istable(data.part) then
 		local ent = Entity(tonumber(data.part.self.OwnerName) or -1)
 		if ent:IsValid() then
 			if not pace.CanPlayerModify(data.owner, ent) then
@@ -142,7 +142,7 @@ function pace.SubmitPart(data, filter)
 				ent:CallOnRemove("pac_config", function(ent)
 					if ent.pac_parts then
 						for _, data in pairs(ent.pac_parts) do
-							if type(data.part) == "table" then
+							if istable(data.part) then
 								data.part = data.part.self.UniqueID
 							end
 							pace.RemovePart(data)
@@ -161,7 +161,7 @@ function pace.SubmitPart(data, filter)
 	local uid = data.uid
 	pace.Parts[uid] = pace.Parts[uid] or {}
 
-	if type(data.part) == "table" then
+	if istable(data.part) then
 		pace.Parts[uid][data.part.self.UniqueID] = data
 	else
 		if data.part == "__ALL__" then
@@ -204,7 +204,7 @@ function pace.SubmitPart(data, filter)
 	local players
 	if IsValid(data.temp_wear_filter) and type(data.temp_wear_filter) == "Player" then
 		players = {data.temp_wear_filter}
-	elseif type(data.wear_filter) == 'table' then
+	elseif istable(data.wear_filter) then
 		players = {}
 
 		for _, id in ipairs(data.wear_filter) do
@@ -238,7 +238,7 @@ function pace.SubmitPart(data, filter)
 
 		local players = filter or players
 
-		if type(players) == "table" then
+		if istable(players) then
 			for key = #players, 1, -1 do
 				local ply = players[key]
 				if not ply.pac_requested_outfits and ply ~= data.owner then
@@ -251,7 +251,7 @@ function pace.SubmitPart(data, filter)
 				for key, ply in pairs(players) do
 					local steamid = ply:SteamID()
 					for var, reason in pairs(pace.GlobalBans) do
-						if  var == steamid or type(var) == "table" and (table.HasValue(var, steamid) or table.HasValue(var, util.CRC(ply:IPAddress():match("(.+):") or ""))) then
+						if  var == steamid or istable(var) and (table.HasValue(var, steamid) or table.HasValue(var, util.CRC(ply:IPAddress():match("(.+):") or ""))) then
 							table.remove(players, key)
 
 							if owner_steamid == steamid then
@@ -267,7 +267,7 @@ function pace.SubmitPart(data, filter)
 			return true
 		end
 
-		if not players or type(players) == "table" and not next(players) then return true end
+		if not players or istable(players) and not next(players) then return true end
 
 		-- Alternative transmission system
 		local ret = hook.Run("pac_SendData", players, data)
@@ -286,7 +286,7 @@ function pace.SubmitPart(data, filter)
 			end
 		end
 
-		if type(data.part) == "table" then
+		if istable(data.part) then
 			last_frame = frame_number
 			pace.CallHook("OnWoreOutfit", data.owner, data.part)
 		end
@@ -306,7 +306,7 @@ function pace.SubmitPartNotify(data)
 	if data.owner:IsPlayer() then
 		if allowed == "queue" then return end
 
-		if not reason and allowed and type(data.part) == 'table' then
+		if not reason and allowed and istable(data.part) then
 			reason = string.format('Your part %q has been applied', data.part.self.Name or '<unknown>')
 		end
 
@@ -339,11 +339,11 @@ function pace.HandleReceivedData(ply, data)
 		data.wear_filter = nil
 	end
 
-	if type(data.part) == "table" and data.part.self then
-		if type(data.part.self) == "table" and not data.part.self.UniqueID then return end -- bogus data
+	if istable(data.part) and data.part.self then
+		if istable(data.part.self) and not data.part.self.UniqueID then return end -- bogus data
 
 		pace.SubmitPartNotify(data)
-	elseif type(data.part) == "string" then
+	elseif isstring(data.part) then
 		pace.RemovePart(data)
 	end
 end

--- a/lua/pac3/extra/client/pac2_compat.lua
+++ b/lua/pac3/extra/client/pac2_compat.lua
@@ -499,9 +499,9 @@ do
 		return self.p, self.i+1
 	end
 	function glon.decode(data)
-		if type(data) == "nil" then
+		if data == nil then
 			return nil
-		elseif type(data) ~= "string" then
+		elseif not isstring(data) then
 			error(string.format("Expected string to decode! (Got type %s)",
 				type(data)
 			))

--- a/lua/pac3/extra/server/map_outfit.lua
+++ b/lua/pac3/extra/server/map_outfit.lua
@@ -144,7 +144,7 @@ concommand.Add("pac_spawn_map", function(ply, _, args)
 	if data then
 		data = CompileString("return {" .. data .. "}", "luadata", true)
 
-		if type(data) == "function" then
+		if isfunction(data) then
 			pacx.SpawnMapOutfit(data())
 		else
 			pac.Message(data)

--- a/lua/pac3/extra/shared/pac_weapon.lua
+++ b/lua/pac3/extra/shared/pac_weapon.lua
@@ -71,7 +71,7 @@ if CLIENT then
 
 	BUILDER:StartStorableVars()
 		for key, val in pairs(SWEP) do
-			if type(val) ~= "table" and type(val) ~= "function" then
+			if not istable(val) and not isfunction(val) then
 				BUILDER:GetSet(key, val)
 			end
 		end

--- a/lua/pac3/libraries/animations.lua
+++ b/lua/pac3/libraries/animations.lua
@@ -28,11 +28,11 @@ do
 		end
 
 
-		if type(data.Type) == "number" then
+		if isnumber(data.Type) then
 			data.Type = old_types[data.Type]
 		end
 
-		if type(data.Interpolation) == "number" then
+		if isnumber(data.Interpolation) then
 			data.Interpolation = old_interpolations[data.Interpolation]
 		end
 
@@ -212,7 +212,7 @@ do
 			&& ( 1 - OutBounce( 1 - 2 * x ) ) / 2
 			|| ( 1 + OutBounce( 2 * x - 1 ) ) / 2
 	end
-	
+
 end
 
 function animations.GetRegisteredAnimations()
@@ -359,7 +359,7 @@ local function ProcessAnimations(ent)
 		local fAmount = fPower * fFrameDelta
 
 		for iBoneID, tBoneInfo in pairs(tFrameData.BoneInfo) do
-			if type(iBoneID) ~= "number" then
+			if not isnumber(iBoneID) then
 				iBoneID = ent:LookupBone(iBoneID)
 			end
 			if not iBoneID then goto CONTINUE end

--- a/lua/pac3/libraries/expression.lua
+++ b/lua/pac3/libraries/expression.lua
@@ -58,7 +58,7 @@ local function compile_expression(str, extra_lib)
 
 	local func = CompileString(str, "pac_expression", false)
 
-	if type(func) == "string" then
+	if isstring(func) then
 		return false, func
 	else
 		setfenv(func, functions)

--- a/lua/pac3/libraries/luadata.lua
+++ b/lua/pac3/libraries/luadata.lua
@@ -207,10 +207,10 @@ luadata.Types = {
 	end,
 	["table"] = function(var)
 		if
-			type(var.r) == "number" and
-			type(var.g) == "number" and
-			type(var.b) == "number" and
-			type(var.a) == "number"
+			isnumber(var.r) and
+			isnumber(var.g) and
+			isnumber(var.b) and
+			isnumber(var.a)
 		then
 			return ("Color(%s, %s, %s, %s)"):format(var.r, var.g, var.b, var.a)
 		end
@@ -283,7 +283,7 @@ local env = {
 function luadata.Decode(str,nojail)
 	local func = CompileString(string.format("return { %s }",str), "luadata_decode", false)
 
-	if type(func) == "string" then
+	if isstring(func) then
 		--ErrorNoHalt("Luadata decode syntax: "..tostring(func):gsub("^luadata_decode","")..'\n')
 
 		return nil,func

--- a/lua/pac3/libraries/resource.lua
+++ b/lua/pac3/libraries/resource.lua
@@ -35,7 +35,7 @@ local function utility_CreateCallbackThing(cache)
 			end
 
 			if cache[path].callback then
-				if type(cache[path].callback) ~= 'table' then cache[path].callback = {cache[path].callback} end
+				if not istable(cache[path].callback) then cache[path].callback = {cache[path].callback} end
 				table.insert(cache[path].callback, callback)
 				return true
 			end
@@ -43,7 +43,7 @@ local function utility_CreateCallbackThing(cache)
 	end
 
 	function self:start(path, callback, extra)
-		if type(callback) ~= 'table' then callback = {callback} end
+		if not istable(callback) then callback = {callback} end
 		cache[path] = {callback = table.Copy(callback), extra_callbacks = table.Copy(extra or {})}
 	end
 
@@ -55,7 +55,7 @@ local function utility_CreateCallbackThing(cache)
 	function self:stop(path, out, ...)
 		if not cache[path] then return end
 
-		if type(cache[path].callback) == 'table' then
+		if istable(cache[path].callback) then
 			for i, func in ipairs(cache[path].callback) do
 				func(out, ...)
 			end
@@ -258,9 +258,9 @@ function resource.Download(path, callback, on_fail, crc, check_etag)
 	if existing_path and not check_etag then
 		ohno = true
 
-		if type(callback) == 'function' then
+		if isfunction(callback) then
 			callback(existing_path)
-		elseif type(callback) == 'table' then
+		elseif istable(callback) then
 			for i, func in ipairs(callback) do
 				func(existing_path)
 			end

--- a/lua/pac3/libraries/string_stream.lua
+++ b/lua/pac3/libraries/string_stream.lua
@@ -35,17 +35,17 @@ local function StringStream(stream, i, endian)
 	}, ss_meta)
 
 	if stream~=nil then
-		assert(type(stream) == "string", "stream must be a string")
+		assert(isstring(stream), "stream must be a string")
 		ret:write(stream)
 		if i~=nil then
-			assert(type(i) == "number", "i must be a number")
+			assert(isnumber(i), "i must be a number")
 			ret:seek(i)
 		else
 			ret:seek(1)
 		end
 	end
 	if endian~=nil then
-		assert(type(endian) == "string", "endian must be a string")
+		assert(isstring(endian), "endian must be a string")
 		ret:setEndian(endian)
 	end
 

--- a/lua/pac3/libraries/urltex.lua
+++ b/lua/pac3/libraries/urltex.lua
@@ -60,7 +60,7 @@ function urltex.GetMaterialFromURL(url, callback, skip_cache, shader, size, size
 		noclamp or
 		noclampT
 
-	if type(callback) == "function" and not skip_cache and urltex.Cache[urlIndex] then
+	if isfunction(callback) and not skip_cache and urltex.Cache[urlIndex] then
 		local tex = urltex.Cache[urlIndex]
 		local mat = CreateMaterial("pac3_urltex_" .. pac.Hash(), shader, additionalData)
 		mat:SetTexture("$basetexture", tex)

--- a/lua/pac3/libraries/webaudio.lua
+++ b/lua/pac3/libraries/webaudio.lua
@@ -962,7 +962,7 @@ do
 
 	function META:__newindex(key, val)
 		if key == "OnFFT" then
-			if type(val) == "function" then
+			if isfunction(val) then
 				self:Call(".usefft(true)")
 			else
 				self:Call(".usefft(false)")

--- a/lua/pac3/libraries/webaudio/stream.lua
+++ b/lua/pac3/libraries/webaudio/stream.lua
@@ -412,7 +412,7 @@ end
 
 function STREAM:__newindex(key, val)
 	if key == "OnFFT" then
-		if type(val) == "function" then
+		if isfunction(val) then
 			self:Call(".usefft(true)")
 		else
 			self:Call(".usefft(false)")


### PR DESCRIPTION
Let's save some CPU cycles by using `is*` functions instead of `type`, by omitting the string comparison of the object type we get returned by `type`.