### PR TITLE
Waive unnecessary writing from "pac_webaudio2_blankhtml.txt"

### DIFF
--- a/lua/pac3/libraries/webaudio.lua
+++ b/lua/pac3/libraries/webaudio.lua
@@ -558,8 +558,7 @@ open();
 		webaudio.browser_panel:RunJavascript(js)
 	end
 
-	file.Write("pac_webaudio2_blankhtml.txt", "<html></html>")
-	webaudio.browser_panel:OpenURL("asset://garrysmod/data/pac_webaudio2_blankhtml.txt")
+	webaudio.browser_panel:SetHTML("<html></html>")
 
 	webaudio.eye_pos = Vector()
 	webaudio.eye_ang = Angle()


### PR DESCRIPTION
Honestly, I don't understand why this exists at all, you can realize it with SetHTML without unnecessarily writing it as a file.