### PR TITLE
Fix an HTML injection exploit

### DIFF
--- a/lua/pac3/core/shared/http.lua
+++ b/lua/pac3/core/shared/http.lua
@@ -63,11 +63,7 @@ end
 
 function pac.FixUrl(url)
 	url = url:Trim()
-
-	url = string.Replace(url, [["]], "")
-	url = string.Replace(url, [[']], "")
-	url = string.Replace(url, ">", "")
-	url = string.Replace(url, "<", "")
+	url = url:gsub("[\"'<>\n\\]+", "")
 
 	if url:find("dropbox", 1, true) then
 		url = url:gsub([[^http%://dl%.dropboxusercontent%.com/]], [[https://dl.dropboxusercontent.com/]])

--- a/lua/pac3/core/shared/http.lua
+++ b/lua/pac3/core/shared/http.lua
@@ -64,6 +64,11 @@ end
 function pac.FixUrl(url)
 	url = url:Trim()
 
+	url = string.Replace(url, [["]], "")
+	url = string.Replace(url, [[']], "")
+	url = string.Replace(url, ">", "")
+	url = string.Replace(url, "<", "")
+
 	if url:find("dropbox", 1, true) then
 		url = url:gsub([[^http%://dl%.dropboxusercontent%.com/]], [[https://dl.dropboxusercontent.com/]])
 		url = url:gsub([[^https?://dl.dropbox.com/]], [[https://www.dropbox.com/]])

--- a/lua/pac3/libraries/urltex.lua
+++ b/lua/pac3/libraries/urltex.lua
@@ -114,7 +114,7 @@ function urltex.StartDownload(url, data)
 	end
 
 	url = pac.FixUrl(url)
-	local size = data.size or urltex.TextureSize
+	local size = tonumber(data.size or urltex.TextureSize)
 	local id = "urltex_download_" .. url
 	local pnl
 	local frames_passed = 0


### PR DESCRIPTION
Because the URL for this part is injected into an HTML blob, attackers can manually send a malicious part that can run arbitrary javascript code on any client that renders their PAC.

My fix updates the `pac.FixUrl` method to strip out exploitative HTML characters (that aren't valid in URLs anyway), and ensures that the `size` parameter is a number before concatenating it into the HTML blob.

This has been tested on our server and works as expected with no noticeable side effects.

Big thanks to @plally for helping me quickly investigate this.