### PR TITLE
quality of life: flipping the sign and switching hand sides

### DIFF
--- a/lua/pac3/editor/client/panels/properties.lua
+++ b/lua/pac3/editor/client/panels/properties.lua
@@ -832,18 +832,47 @@ do -- base editable
 			self:SetValue(pac.CopyValue(pace.clipboard))
 			self.OnValueChanged(self:GetValue())
 		end):SetImage(pace.MiscIcons.paste)
-		menu:AddSpacer()
-		menu:AddOption(L"change sides", function()
-			local content = self:GetValue()
-			local content_flip
-			if string.match(content, "left") != nil then
-				content_flip = string.gsub(content,"left","right")
-			elseif string.match(content, "right") != nil then
-				content_flip = string.gsub(content,"right","left")
-			end
-			self:SetValue(content_flip or content)
-			self.OnValueChanged(self:GetValue())
+		
+		--left right swap available on strings (and parts)
+		if type(self:GetValue()) == 'string' then
+			menu:AddSpacer()
+			menu:AddOption(L"change sides", function()
+				local var
+				local part
+				if self.udata and self.udata.editor_panel == "part" then
+					part = pac.GetPartFromUniqueID(pac.Hash(pac.LocalPlayer), self:GetValue())
+					var = part:IsValid() and part:GetName()
+				else
+					var = self:GetValue()
+				end
+				
+				local var_flip
+				if string.match(var, "left") != nil then
+					var_flip = string.gsub(var,"left","right")
+				elseif string.match(var, "right") != nil then
+					var_flip = string.gsub(var,"right","left")
+				end
+				
+				if self.udata and self.udata.editor_panel == "part" then
+					local target = pac.FindPartByName(pac.Hash(pac.LocalPlayer), var_flip or var, pace.current_part)
+					self:SetValue(target or part)
+					self.OnValueChanged(target or part)
+				else
+                self:SetValue(var_flip or var)
+                self.OnValueChanged(var_flip or var)
+            end
 		end):SetImage("icon16/arrow_switch.png")
+		
+		--numeric sign flip available on numbers
+		elseif type(self:GetValue()) == 'number' then
+			menu:AddSpacer()
+			menu:AddOption(L"flip sign (+/-)", function()
+				local val = self:GetValue()
+				self:SetValue(-val)
+				self.OnValueChanged(self:GetValue())
+			end):SetImage("icon16/arrow_switch.png")
+		end
+		
 		menu:AddSpacer()
 		menu:AddOption(L"reset", function()
 			if pace.current_part and pace.current_part.DefaultVars[self.CurrentKey] then
@@ -1321,7 +1350,7 @@ do -- vector
 			if input.IsKeyDown(KEY_LCONTROL) then
 				num = math.Round(num)
 			end
-
+			
 			return tostring(num)
 		end,
 
@@ -1472,6 +1501,7 @@ do -- number
 			elseif input.IsKeyDown(KEY_PAD_MINUS) or input.IsKeyDown(KEY_MINUS) then
 				num = -num
 			end
+			
 
 			if input.IsKeyDown(KEY_LALT) then
 				num = math.Round(num, 5)

--- a/lua/pac3/editor/client/panels/properties.lua
+++ b/lua/pac3/editor/client/panels/properties.lua
@@ -833,6 +833,18 @@ do -- base editable
 			self.OnValueChanged(self:GetValue())
 		end):SetImage(pace.MiscIcons.paste)
 		menu:AddSpacer()
+		menu:AddOption(L"change sides", function()
+			local content = self:GetValue()
+			local content_flip
+			if string.match(content, "left") != nil then
+				content_flip = string.gsub(content,"left","right")
+			elseif string.match(content, "right") != nil then
+				content_flip = string.gsub(content,"right","left")
+			end
+			self:SetValue(content_flip or content)
+			self.OnValueChanged(self:GetValue())
+		end):SetImage("icon16/arrow_switch.png")
+		menu:AddSpacer()
 		menu:AddOption(L"reset", function()
 			if pace.current_part and pace.current_part.DefaultVars[self.CurrentKey] then
 				local val = pac.CopyValue(pace.current_part.DefaultVars[self.CurrentKey])
@@ -1457,6 +1469,8 @@ do -- number
 		if self:IsMouseDown() then
 			if input.IsKeyDown(KEY_LCONTROL) then
 				num = math.Round(num)
+			elseif input.IsKeyDown(KEY_PAD_MINUS) or input.IsKeyDown(KEY_MINUS) then
+				num = -num
 			end
 
 			if input.IsKeyDown(KEY_LALT) then


### PR DESCRIPTION
minus or numpad minus + left clicking on a number (or vector component) will invert the sign between negative and positive

upon right clicking a string property, between paste and reset, a new option, "change sides" will change "right" to "left", or vice versa (but it doesn't work if the property is a part yet)