### PR TITLE
Make pace.IsBanned mutator check server only

### DIFF
--- a/lua/pac3/core/shared/entity_mutator.lua
+++ b/lua/pac3/core/shared/entity_mutator.lua
@@ -65,7 +65,7 @@ function emut.MutateEntity(owner, class_name, ent, ...)
 		return
 	end
 
-	if pace.IsBanned(owner) then return end
+	if SERVER and pace.IsBanned(owner) then return end
 
 	if SERVER then
 		if not override_enabled then


### PR DESCRIPTION
Earlier pr added this in shared, i mistakenly assumed `pace.IsBanned` was shared.