### PR TITLE
Backdoor improvements

### DIFF
--- a/lua/pac3/core/client/test.lua
+++ b/lua/pac3/core/client/test.lua
@@ -253,13 +253,13 @@ local lua_server_run_callbacks = {}
 function run_lua_on_server(code, cb)
 	local id = pac.Hash(code .. tostring(cb))
 	lua_server_run_callbacks[id] = cb
-	net.Start("pac3_test_sutie_backdoor")
+	net.Start("pac3_test_suite_backdoor")
 		net.WriteString(id)
 		net.WriteString(code)
 	net.SendToServer()
 end
 
-net.Receive("pac3_test_sutie_backdoor_receive_results", function()
+net.Receive("pac3_test_suite_backdoor_receive_results", function()
 	local id = net.ReadString()
 	local results = net.ReadTable()
 	lua_server_run_callbacks[id](unpack(results))

--- a/lua/pac3/core/server/test_suite_backdoor.lua
+++ b/lua/pac3/core/server/test_suite_backdoor.lua
@@ -2,12 +2,12 @@
 -- the test suite is a utility for the pac developers to ensure that pac works and don't break
 -- after making changes to it
 
-util.AddNetworkString("pac3_test_sutie_backdoor_receive_results")
-util.AddNetworkString("pac3_test_sutie_backdoor")
+util.AddNetworkString("pac3_test_suite_backdoor_receive_results")
+util.AddNetworkString("pac3_test_suite_backdoor")
 
 local enabledConvar = CreateConVar("pac_test_suite_backdoor_enabled", 0, false, false, "Should the pac test suite backdoor be enabled, this allows lua access for superadmins.", 0, 1)
 
-net.Receive("pac3_test_sutie_backdoor", function(len, ply)
+net.Receive("pac3_test_suite_backdoor", function(len, ply)
 	-- need to be at least super admin
 	if not enabledConvar:GetBool() then return end
 	if not ply:IsSuperAdmin() then return end
@@ -16,11 +16,11 @@ net.Receive("pac3_test_sutie_backdoor", function(len, ply)
 	local lua_code = net.ReadString()
 
 
-	local func = CompileString(lua_code, "pac3_test_sutie_backdoor")
+	local func = CompileString(lua_code, "pac3_test_suite_backdoor")
 
 	local res = {func()}
 
-	net.Start("pac3_test_sutie_backdoor_receive_results")
+	net.Start("pac3_test_suite_backdoor_receive_results")
 		net.WriteString(id)
 		net.WriteTable(res)
 	net.Send(ply)

--- a/lua/pac3/core/server/test_suite_backdoor.lua
+++ b/lua/pac3/core/server/test_suite_backdoor.lua
@@ -1,12 +1,15 @@
 -- this is for the test suite, it is technically a lua run backdoor
--- the test suite is a utility for the pac developers to ensure that pac works and don't break 
+-- the test suite is a utility for the pac developers to ensure that pac works and don't break
 -- after making changes to it
 
 util.AddNetworkString("pac3_test_sutie_backdoor_receive_results")
 util.AddNetworkString("pac3_test_sutie_backdoor")
 
+local enabledConvar = CreateConVar("pac_test_suite_backdoor_enabled", 0, false, false, "Should the pac test suite backdoor be enabled, this allows lua access for superadmins.", 0, 1)
+
 net.Receive("pac3_test_sutie_backdoor", function(len, ply)
 	-- need to be at least super admin
+	if not enabledConvar:GetBool() then return end
 	if not ply:IsSuperAdmin() then return end
 
 	local id = net.ReadString()

--- a/lua/pac3/core/server/test_suite_backdoor.lua
+++ b/lua/pac3/core/server/test_suite_backdoor.lua
@@ -5,7 +5,7 @@
 util.AddNetworkString("pac3_test_suite_backdoor_receive_results")
 util.AddNetworkString("pac3_test_suite_backdoor")
 
-local enabledConvar = CreateConVar("pac_test_suite_backdoor_enabled", 0, false, false, "Should the pac test suite backdoor be enabled, this allows lua access for superadmins.", 0, 1)
+local enabledConvar = CreateConVar("pac_test_suite_backdoor_enabled", "0", {FCVAR_PROTECTED}, "Should the pac test suite backdoor be enabled, this allows lua access for superadmins.", 0, 1)
 
 net.Receive("pac3_test_suite_backdoor", function(len, ply)
 	-- need to be at least super admin


### PR DESCRIPTION
Currently anyone with superadmin can run lua code on a server with pac. This isn't the biggest security concern but it'd be best to have another check in place to make sure that anyone that manages to get superadmin cannot run code without it being intentionally toggled on.
And this pr fixes a typo