### PR TITLE
Add leaky bucket ratelimiting system and use it in e2 core

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/custom/pac.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/pac.lua
@@ -6,8 +6,8 @@ util.AddNetworkString("pac_e2_setkeyvalue_vec")
 util.AddNetworkString("pac_e2_setkeyvalue_ang")
 
 local enabledConvar = CreateConVar("pac_e2_ratelimit_enable", "1", {FCVAR_ARCHIVE}, "If the e2 ratelimit should be enabled.", 0, 1)
-local rate = CreateConVar("pac_e2_ratelimit_refill", "0.25", {FCVAR_ARCHIVE}, "The speed at which the ratelimit buffer refills.", 0, 1000)
-local buffer = CreateConVar("pac_e2_ratelimit_buffer", "30", {FCVAR_ARCHIVE}, "How large the ratelimit buffer should be.", 0, 1000)
+local rate = CreateConVar("pac_e2_ratelimit_refill", "0.025", {FCVAR_ARCHIVE}, "The speed at which the ratelimit buffer refills.", 0, 1000)
+local buffer = CreateConVar("pac_e2_ratelimit_buffer", "300", {FCVAR_ARCHIVE}, "How large the ratelimit buffer should be.", 0, 1000)
 
 local function canRunFunction(self)
 	if not enabledConvar:GetBool() then return true end

--- a/lua/entities/gmod_wire_expression2/core/custom/pac.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/pac.lua
@@ -1,7 +1,27 @@
 E2Lib.RegisterExtension("pac", true)
 
 util.AddNetworkString("pac_e2_setkeyvalue_str")
+util.AddNetworkString("pac_e2_setkeyvalue_num")
+util.AddNetworkString("pac_e2_setkeyvalue_vec")
+util.AddNetworkString("pac_e2_setkeyvalue_ang")
+
+local enabledConvar = CreateConVar("pac_e2_ratelimit_enable", "1", {FCVAR_ARCHIVE}, "If the e2 ratelimit should be enabled.", 0, 1)
+local rate = CreateConVar("pac_e2_ratelimit_refill", "0.25", {FCVAR_ARCHIVE}, "The speed at which the ratelimit buffer refills.", 0, 1000)
+local buffer = CreateConVar("pac_e2_ratelimit_buffer", "30", {FCVAR_ARCHIVE}, "How large the ratelimit buffer should be.", 0, 1000)
+
+local function canRunFunction(self)
+	if not enabledConvar:GetBool() then return true end
+
+	local allowed = pac.RatelimitPlayer(self.player, "e2_extension", buffer:GetInt(), rate:GetInt())
+	if not allowed then
+		E2Lib.raiseException("pac3 e2 ratelimit exceeded")
+		return false
+	end
+	return true
+end
+
 e2function void pacSetKeyValue(entity owner, string global_id, string key, string value)
+	if not canRunFunction(self) then return end
 	net.Start("pac_e2_setkeyvalue_str")
 		net.WriteEntity(self.player)
 		net.WriteEntity(owner)
@@ -12,8 +32,8 @@ e2function void pacSetKeyValue(entity owner, string global_id, string key, strin
 	net.Broadcast()
 end
 
-util.AddNetworkString("pac_e2_setkeyvalue_num")
 e2function void pacSetKeyValue(entity owner, string global_id, string key, number value)
+	if not canRunFunction(self) then return end
 	net.Start("pac_e2_setkeyvalue_num")
 		net.WriteEntity(self.player)
 		net.WriteEntity(owner)
@@ -24,8 +44,8 @@ e2function void pacSetKeyValue(entity owner, string global_id, string key, numbe
 	net.Broadcast()
 end
 
-util.AddNetworkString("pac_e2_setkeyvalue_vec")
 e2function void pacSetKeyValue(entity owner, string global_id, string key, vector value)
+	if not canRunFunction(self) then return end
 	net.Start("pac_e2_setkeyvalue_vec")
 		net.WriteEntity(self.player)
 		net.WriteEntity(owner)
@@ -36,8 +56,8 @@ e2function void pacSetKeyValue(entity owner, string global_id, string key, vecto
 	net.Broadcast()
 end
 
-util.AddNetworkString("pac_e2_setkeyvalue_ang")
 e2function void pacSetKeyValue(entity owner, string global_id, string key, angle value)
+	if not canRunFunction(self) then return end
 	net.Start("pac_e2_setkeyvalue_ang")
 		net.WriteEntity(self.player)
 		net.WriteEntity(owner)

--- a/lua/pac3/core/server/util.lua
+++ b/lua/pac3/core/server/util.lua
@@ -46,19 +46,6 @@ function pac.RemoveHook(str, id)
 	hook.Remove(str, id)
 end
 
-function pac.RateLimitPlayer(ply, name)
-	local ratelimitName = "pac_ratelimit_" .. name
-	if not ply[ratelimitName] then
-		ply[ratelimitName] = 0
-	end
-
-	if ply[ratelimitName] > CurTime() then
-		return false
-	end
-
-	ply["pac_rate_limit_" .. name] = ply["pac_rate_limit_" .. name] + 1
-end
-
 function pac.RatelimitPlayer( ply, name, buffer, refill )
 	local ratelimitName = "pac_ratelimit_" .. name
 	local checkName = "pac_ratelimit_check_" .. name

--- a/lua/pac3/core/server/util.lua
+++ b/lua/pac3/core/server/util.lua
@@ -1,3 +1,6 @@
+local CurTime = CurTime
+local math_Clamp = math.Clamp
+
 function pac.dprint(fmt, ...)
 	if pac.debug then
 		MsgN("\n")
@@ -41,4 +44,42 @@ function pac.RemoveHook(str, id)
 	id = "pac_" .. id
 
 	hook.Remove(str, id)
+end
+
+function pac.RateLimitPlayer(ply, name)
+	local ratelimitName = "pac_ratelimit_" .. name
+	if not ply[ratelimitName] then
+		ply[ratelimitName] = 0
+	end
+
+	if ply[ratelimitName] > CurTime() then
+		return false
+	end
+
+	ply["pac_rate_limit_" .. name] = ply["pac_rate_limit_" .. name] + 1
+end
+
+function pac.RatelimitPlayer( ply, name, buffer, refill )
+	local ratelimitName = "pac_ratelimit_" .. name
+	local checkName = "pac_ratelimit_check_" .. name
+
+	if not ply[ratelimitName] then ply[ratelimitName] = buffer end
+
+	local curTime = CurTime()
+	if not ply[checkName] then ply[checkName] = curTime end
+
+	local dripSize = curTime - ply[checkName]
+	ply[checkName] = curTime
+
+	local drip = dripSize / refill
+	local newVal = ply[ratelimitName] + drip
+
+	ply[ratelimitName] = math_Clamp(newVal, 0, buffer)
+
+	if ply[ratelimitName] >= 1 then
+		ply[ratelimitName] = ply[ratelimitName] - 1
+		return true
+	else
+		return false
+	end
 end

--- a/lua/pac3/core/server/util.lua
+++ b/lua/pac3/core/server/util.lua
@@ -83,3 +83,8 @@ function pac.RatelimitPlayer( ply, name, buffer, refill )
 		return false
 	end
 end
+
+function pac.GetRateLimitPlayerBuffer( ply, name )
+	local ratelimitName = "pac_ratelimit_" .. name
+	return ply[ratelimitName] or 0
+end

--- a/lua/pac3/extra/client/wire_expression_extension.lua
+++ b/lua/pac3/extra/client/wire_expression_extension.lua
@@ -1,3 +1,5 @@
+local IsValid = IsValid
+
 hook.Add("pac_Initialized", "pac_e2_extension", function()
 	if E2Helper then
 		E2Helper.Descriptions["pacSetKeyValue"] = "Sets a property value on given part. Part unique id is recommended but you can also input name."
@@ -8,6 +10,7 @@ local function SetKeyValue(ply, ent, unique_id, key, val)
 	local set = "Set" .. key
 
 	local part = pac.GetPartFromUniqueID(pac.Hash(ply), unique_id)
+	if not IsValid( part ) then return end
 
 	if part:GetRootPart():GetOwner() == ent then
 		if key == "EventHide" then


### PR DESCRIPTION
This pr adds `pac.RatelimitPlayer` which allows any pac function to easily implement a leaky bucket like ratelimit. The benefit of using a leaky bucket system over a regular system is that it allows more freedom for regular users yet still prevents excessive abuse.

I've implemented this on the e2 core and added convars to disable it. I also added a simple fix for the e2 core as currently players can spam everyones console with lua errors using e2.

The leaky bucket code is a little bit experimental but i couldn't find any issues with it when i tested it.