### PR TITLE
Reduce globals

### DIFF
--- a/lua/pac3/core/client/owner_name.lua
+++ b/lua/pac3/core/client/owner_name.lua
@@ -41,7 +41,7 @@ pac.WorldEntity = NULL
 
 function pac.GetWorldEntity()
 	if not pac.WorldEntity:IsValid() then
-		ent = pac.CreateEntity("models/error.mdl")
+		local ent = pac.CreateEntity("models/error.mdl")
 
 		ent:SetPos(Vector(0,0,0))
 

--- a/lua/pac3/core/client/tests/events.lua
+++ b/lua/pac3/core/client/tests/events.lua
@@ -98,7 +98,6 @@ function test.Run(done)
 		local event = root:CreatePart("event")
 		event:SetEvent("test")
 		event:SetAffectChildrenOnly(true)
-		event_part = event
 
 		local child = event:CreatePart("test")
 	end

--- a/lua/pac3/editor/client/about.lua
+++ b/lua/pac3/editor/client/about.lua
@@ -554,7 +554,7 @@ function pace.ShowAbout()
 
 		first = false
 
-		quit = input.IsKeyDown(KEY_SPACE) or input.IsKeyDown(KEY_ESCAPE) or not ok
+		local quit = input.IsKeyDown(KEY_SPACE) or input.IsKeyDown(KEY_ESCAPE) or not ok
 
 		if quit then
 			if not ok then print(err) end

--- a/lua/pac3/editor/client/about.lua
+++ b/lua/pac3/editor/client/about.lua
@@ -68,8 +68,8 @@ do
 		}
 	end
 
-	def_color1 = Color(255, 255, 255, 255)
-	def_color2 = Color(0, 0, 0, 255)
+	local def_color1 = Color(255, 255, 255, 255)
+	local def_color2 = Color(0, 0, 0, 255)
 
 	local surface_SetFont = surface.SetFont
 	local surface_SetTextColor = surface.SetTextColor

--- a/lua/pac3/editor/client/asset_browser.lua
+++ b/lua/pac3/editor/client/asset_browser.lua
@@ -632,13 +632,14 @@ function pace.AssetBrowser(callback, browse_types_str, part_key)
 	local last_w
 	local last_h
 	local div_x
+	local last_div_x
 
 	local old_think = frame.Think
 	frame.Think = function(...)
 		local x,y = frame:GetPos()
 		local w,h = frame:GetSize()
 
-		local div_x = divider:GetLeftWidth()
+		div_x = divider:GetLeftWidth()
 
 		if x ~= last_x then frame:SetCookie("x", x) last_x = x end
 		if y ~= last_y then frame:SetCookie("y", y) last_y = y end

--- a/lua/pac3/editor/client/logic.lua
+++ b/lua/pac3/editor/client/logic.lua
@@ -3,6 +3,7 @@ pace.properties = NULL
 pace.tree = NULL
 
 local L = pace.LanguageString
+local alreadyInCall
 
 function pace.PopulateProperties(part)
 	if pace.properties:IsValid() then

--- a/lua/pac3/editor/client/panels/lua_editor.lua
+++ b/lua/pac3/editor/client/panels/lua_editor.lua
@@ -702,7 +702,7 @@ function PANEL:ScrollCaret()
 	self.ScrollBar:SetScroll(self.Scroll[1] - 1)
 end
 
-function unindent(line)
+local function unindent(line)
 	local i = line:find("%S")
 	if(i == nil or i > 5) then i = 5 end
 	return line:sub(i)

--- a/lua/pac3/editor/client/panels/lua_editor.lua
+++ b/lua/pac3/editor/client/panels/lua_editor.lua
@@ -212,7 +212,7 @@ function PANEL:SyntaxColorLine(row)
 	self.str = ""
 
 	-- TODO: Color customization?
-	colors = {
+	local colors = {
 		["none"] =  { Color(200, 200, 200, 255), false},
 		["number"] =    { Color(218, 165, 32, 255), false},
 		["function"] =  { Color(100, 100, 255, 255), false},
@@ -318,7 +318,7 @@ function PANEL:SyntaxColorLine(row)
 
 		end
 
-		color = colors[token]
+		local color = colors[token]
 		if(#cols > 1 and color == cols[#cols][2]) then
 			cols[#cols][1] = cols[#cols][1] .. self.str
 		else

--- a/lua/pac3/editor/client/panels/lua_editor.lua
+++ b/lua/pac3/editor/client/panels/lua_editor.lua
@@ -377,7 +377,7 @@ function PANEL:PaintLine(row)
 	for i,cell in ipairs(self.PaintRows[row]) do
 		if(offset < 0) then
 			if(string.len(cell[1]) > -offset) then
-				line = string.sub(cell[1], -offset + 1)
+				local line = string.sub(cell[1], -offset + 1)
 				offset = string.len(line)
 
 				if(cell[2][2]) then

--- a/lua/pac3/editor/client/panels/lua_editor.lua
+++ b/lua/pac3/editor/client/panels/lua_editor.lua
@@ -229,7 +229,7 @@ function PANEL:SyntaxColorLine(row)
 	self:NextChar();
 
 	while self.char do
-		token = "";
+		local token = "";
 		self.str = "";
 
 		while self.char and self.char == " " do self:NextChar() end

--- a/lua/pac3/editor/client/panels/tree.lua
+++ b/lua/pac3/editor/client/panels/tree.lua
@@ -230,7 +230,6 @@ local function install_drag(node)
 				pace.RecordUndoHistory()
 				self.part:SetParent(child.part)
 				pace.RecordUndoHistory()
-				called = true
 			end
 		elseif self.part and self.part:IsValid() then
 			if self.part.ClassName ~= "group" then
@@ -240,14 +239,12 @@ local function install_drag(node)
 				self.part:SetParent(group)
 				pace.RecordUndoHistory()
 				pace.TrySelectPart()
-				called = true
 
 			else
 				pace.RecordUndoHistory()
 				self.part:SetParent()
 				pace.RecordUndoHistory()
 				pace.RefreshTree(true)
-				called = true
 			end
 		end
 

--- a/lua/pac3/editor/client/parts.lua
+++ b/lua/pac3/editor/client/parts.lua
@@ -239,6 +239,7 @@ function pace.GetRegisteredParts()
 end
 
 do -- menu
+	local trap
 	function pace.AddRegisteredPartsToMenu(menu, parent)
 		local partsToShow = {}
 		local clicked = false
@@ -330,7 +331,7 @@ do -- menu
 				pnl:SetImage(groupData.icon)
 			end
 
-			local trap = false
+			trap = false
 			table.sort(groupData.parts, function(a, b) return a.ClassName < b.ClassName end)
 			for i, part in ipairs(groupData.parts) do
 				add_part(sub, part)

--- a/lua/pac3/editor/client/tools.lua
+++ b/lua/pac3/editor/client/tools.lua
@@ -374,7 +374,7 @@ end)
 pace.AddTool(L"import editor tool from url...", function()
 	if GetConVar("sv_allowcslua"):GetBool() then
 		Derma_StringRequest(L"URL", L"URL to PAC Editor tool txt file", "http://www.example.com/tool.txt", function(toolurl)
-			function ToolDLSuccess(body)
+			local function ToolDLSuccess(body)
 				local toolname = pac.PrettifyName(toolurl:match(".+/(.-)%."))
 				local toolstr = body
 				ctoolstr = [[pace.AddTool(L"]] .. toolname .. [[", function(part, suboption)]] .. toolstr .. " end)"

--- a/lua/pac3/editor/client/tools.lua
+++ b/lua/pac3/editor/client/tools.lua
@@ -359,7 +359,7 @@ pace.AddTool(L"import editor tool from file...", function()
 		Derma_StringRequest(L"filename", L"relative to garrysmod/data/pac3_editor/tools/", "mytool.txt", function(toolfile)
 			if file.Exists("pac3_editor/tools/" .. toolfile,"DATA") then
 				local toolstr = file.Read("pac3_editor/tools/" .. toolfile,"DATA")
-				ctoolstr = [[pace.AddTool(L"]] .. toolfile .. [[", function(part, suboption) ]] .. toolstr .. " end)"
+				local ctoolstr = [[pace.AddTool(L"]] .. toolfile .. [[", function(part, suboption) ]] .. toolstr .. " end)"
 				RunStringEx(ctoolstr, "pac_editor_import_tool")
 				pac.LocalPlayer:ConCommand("pac_editor") --close and reopen editor
 			else
@@ -377,7 +377,7 @@ pace.AddTool(L"import editor tool from url...", function()
 			local function ToolDLSuccess(body)
 				local toolname = pac.PrettifyName(toolurl:match(".+/(.-)%."))
 				local toolstr = body
-				ctoolstr = [[pace.AddTool(L"]] .. toolname .. [[", function(part, suboption)]] .. toolstr .. " end)"
+				local ctoolstr = [[pace.AddTool(L"]] .. toolname .. [[", function(part, suboption)]] .. toolstr .. " end)"
 				RunStringEx(ctoolstr, "pac_editor_import_tool")
 				pac.LocalPlayer:ConCommand("pac_editor") --close and reopen editor
 			end
@@ -391,7 +391,7 @@ pace.AddTool(L"import editor tool from url...", function()
 	end
 end)
 
-function round_pretty(val)
+local function round_pretty(val)
 	return math.Round(val, 2)
 end
 

--- a/lua/pac3/editor/client/wires.lua
+++ b/lua/pac3/editor/client/wires.lua
@@ -84,8 +84,6 @@ local function DrawHermite(width, x0,y0,x1,y1,c0,c1,alpha,samples)
 	--render.SetMaterial(Material("cable/smoke.vmt"))
 	render_startBeam(samples+1)
 
-	local t = RealTime()
-
 	for i=1, samples+1 do
 		local curr = positions[i][1]
 		render_addBeam(curr, width, ((i/samples)*10000 - 0.5)%1, positions[i][2])

--- a/lua/pac3/editor/client/wires.lua
+++ b/lua/pac3/editor/client/wires.lua
@@ -1,104 +1,100 @@
 
-do
-	local function CubicHermite(p0, p1, m0, m1, t)
-		local tS = t*t;
-		local tC = tS*t;
+local function CubicHermite(p0, p1, m0, m1, t)
+	local tS = t*t;
+	local tC = tS*t;
 
-		return (2*tC - 3*tS + 1)*p0 + (tC - 2*tS + t)*m0 + (-2*tC + 3*tS)*p1 + (tC - tS)*m1
+	return (2*tC - 3*tS + 1)*p0 + (tC - 2*tS + t)*m0 + (-2*tC + 3*tS)*p1 + (tC - tS)*m1
+end
+
+local vsamples = {}
+for i=1, 100 do vsamples[#vsamples+1] = {Vector(0,0,0), Color(0,0,0,0)} end
+
+local math_sqrt = math.sqrt
+local math_abs = math.abs
+local math_max = math.max
+local math_min = math.min
+local math_cos = math.cos
+local math_pi = math.pi
+
+local mtVector =  FindMetaTable("Vector")
+local mtColor = FindMetaTable("Color")
+local render_startBeam = render.StartBeam
+local render_endBeam = render.EndBeam
+local render_addBeam = render.AddBeam
+local setVecUnpacked = mtVector.SetUnpacked
+local setColUnpacked = mtColor.SetUnpacked
+local colUnpack = mtColor.Unpack
+
+local black = Color(0,0,0,100)
+local vector_add = Vector(0, 2.5, 0)
+
+local function DrawHermite(width, x0,y0,x1,y1,c0,c1,alpha,samples)
+
+	--[[if x0 < 0 and x1 < 0 then return end
+	if x0 > w and x1 > w then return end
+	if y0 < 0 and y1 < 0 then return end
+	if y0 > h and y1 > h then return end]]
+
+	local r0,g0,b0,a0 = colUnpack(c0)
+	local r1,g1,b1,a1 = colUnpack(c1)
+
+	alpha = alpha or 1
+
+	width = width or 5
+	local samples = 20
+	local positions = vsamples
+
+	samples = samples or 20
+
+	local dx = -(x1 - x0)
+	local dy = (y1 - y0)
+
+	local d = math_sqrt(math_max(dx*dx, 8000), dy*dy) * 1.5
+	d = math_max(d, math_abs(dy))
+	d = math_min(d, 1000)
+	d = d * 1.25 / (-dy/300)
+
+	setVecUnpacked(positions[1][1],x0,y0,0)
+	positions[1][2] = c0
+
+	for i=1, samples do
+
+		local t = i/samples
+
+		t = 1 - (.5 + math_cos(t * math_pi) * .5)
+
+		local x = CubicHermite(x0, x1, dx >= 0 and d or -d, d, t)
+		local y = CubicHermite(y0, y1, 0, 0, t)
+
+		setVecUnpacked(positions[i+1][1],x,y,0)
+		setColUnpacked(positions[i+1][2],Lerp(t, r0, r1), Lerp(t, g0, g1), Lerp(t, b0, b1), a0 * alpha)
 	end
 
-	local vsamples = {}
-	for i=1, 100 do vsamples[#vsamples+1] = {Vector(0,0,0), Color(0,0,0,0)} end
+	render.PushFilterMag( TEXFILTER.LINEAR )
+	render.PushFilterMin( TEXFILTER.LINEAR )
 
-	local math_sqrt = math.sqrt
-	local math_abs = math.abs
-	local math_max = math.max
-	local math_min = math.min
-	local math_cos = math.cos
-	local math_pi = math.pi
+	render_startBeam(samples + 1)
 
-	local mtVector =  FindMetaTable("Vector")
-	local mtColor = FindMetaTable("Color")
-	local render_setColorMaterial = render.SetColorMaterial
-	local render_startBeam = render.StartBeam
-	local render_endBeam = render.EndBeam
-	local render_addBeam = render.AddBeam
-	local setVecUnpacked = mtVector.SetUnpacked
-	local setColUnpacked = mtColor.SetUnpacked
-	local colUnpack = mtColor.Unpack
-
-	local black = Color(0,0,0,100)
-	local vector_add = Vector(0, 2.5, 0)
-
-	function DrawHermite(width, x0,y0,x1,y1,c0,c1,alpha,samples)
-
-		--[[if x0 < 0 and x1 < 0 then return end
-		if x0 > w and x1 > w then return end
-		if y0 < 0 and y1 < 0 then return end
-		if y0 > h and y1 > h then return end]]
-
-		local r0,g0,b0,a0 = colUnpack(c0)
-		local r1,g1,b1,a1 = colUnpack(c1)
-
-		alpha = alpha or 1
-
-		width = width or 5
-		local samples = 20
-		local positions = vsamples
-
-		samples = samples or 20
-
-		local dx = -(x1 - x0)
-		local dy = (y1 - y0)
-
-		local d = math_sqrt(math_max(dx*dx, 8000), dy*dy) * 1.5
-		d = math_max(d, math_abs(dy))
-		d = math_min(d, 1000)
-		d = d * 1.25 / (-dy/300)
-
-		setVecUnpacked(positions[1][1],x0,y0,0)
-		positions[1][2] = c0
-
-		for i=1, samples do
-
-			local t = i/samples
-
-			t = 1 - (.5 + math_cos(t * math_pi) * .5)
-
-			local x = CubicHermite(x0, x1, dx >= 0 and d or -d, d, t)
-			local y = CubicHermite(y0, y1, 0, 0, t)
-
-			setVecUnpacked(positions[i+1][1],x,y,0)
-			setColUnpacked(positions[i+1][2],Lerp(t, r0, r1), Lerp(t, g0, g1), Lerp(t, b0, b1), a0 * alpha)
-		end
-
-		render.PushFilterMag( TEXFILTER.LINEAR )
-		render.PushFilterMin( TEXFILTER.LINEAR )
-
-		render_startBeam(samples + 1)
-
-		for i = 1, samples + 1 do
-			render_addBeam(positions[i][1] + vector_add, width, 0.5, black)
-		end
-
-		render_endBeam()
-
-		--render.SetMaterial(Material("cable/smoke.vmt"))
-		render_startBeam(samples+1)
-
-		local t = RealTime()
-
-		for i=1, samples+1 do
-			local curr = positions[i][1]
-			render_addBeam(curr, width, ((i/samples)*10000 - 0.5)%1, positions[i][2])
-		end
-
-		render_endBeam()
-
-		render.PopFilterMag()
-		render.PopFilterMin()
+	for i = 1, samples + 1 do
+		render_addBeam(positions[i][1] + vector_add, width, 0.5, black)
 	end
 
+	render_endBeam()
+
+	--render.SetMaterial(Material("cable/smoke.vmt"))
+	render_startBeam(samples+1)
+
+	local t = RealTime()
+
+	for i=1, samples+1 do
+		local curr = positions[i][1]
+		render_addBeam(curr, width, ((i/samples)*10000 - 0.5)%1, positions[i][2])
+	end
+
+	render_endBeam()
+
+	render.PopFilterMag()
+	render.PopFilterMin()
 end
 
 local function draw_hermite(x,y, w,h, ...)

--- a/lua/pac3/libraries/animations.lua
+++ b/lua/pac3/libraries/animations.lua
@@ -541,7 +541,6 @@ function animations.SetEntityAnimationCycle(ent, name, f)
 		f = f%1
 
 
-		ROFL = f
 		f = f * duration
 
 		local sec = 0


### PR DESCRIPTION
This pr aims to reduce the global table pollution by localizing variables that should've been local.

From:
![image](https://user-images.githubusercontent.com/69946827/201374774-9d4f1d72-2049-43ab-a581-60c99f6c6c9e.png)
![image](https://user-images.githubusercontent.com/69946827/201374787-c16998f6-9ab5-4dce-ac8a-ad9abd721649.png)
The tool didn't display all the old globals, but there where more.

To:
![image](https://user-images.githubusercontent.com/69946827/201374527-f65dfa5f-36dc-4cb5-a709-67b8194dabe6.png)
