### PR TITLE
Fix first call of RatelimitAlert

### DIFF
--- a/lua/pac3/core/server/util.lua
+++ b/lua/pac3/core/server/util.lua
@@ -51,7 +51,7 @@ function pac.RatelimitAlert( ply, id, message )
 		ply.pac_ratelimit_alerts = {}
 	end
 
-	if CurTime() >= ply.pac_ratelimit_alerts[id] or 0 then
+	if CurTime() >= ( ply.pac_ratelimit_alerts[id] or 0 ) then
 		ply.pac_ratelimit_alerts[id] = CurTime() + 3
 		if isstring(message) then
 			pac.Message(message)

--- a/lua/pac3/core/server/util.lua
+++ b/lua/pac3/core/server/util.lua
@@ -51,11 +51,7 @@ function pac.RatelimitAlert( ply, id, message )
 		ply.pac_ratelimit_alerts = {}
 	end
 
-	if not ply.pac_ratelimit_alerts[id] then
-		ply.pac_ratelimit_alerts[id] = CurTime() + 3
-	end
-
-	if CurTime() > ply.pac_ratelimit_alerts[id] then
+	if CurTime() >= ply.pac_ratelimit_alerts[id] or 0 then
 		ply.pac_ratelimit_alerts[id] = CurTime() + 3
 		if isstring(message) then
 			pac.Message(message)


### PR DESCRIPTION
While writing the first-pass of GLuaTest unit tests, I noticed that `pac.RatelimitAlert` might have a bug.

If the given player doesn't have any rate limit data on them at all, it appears that `pac.RatelimitAlert` won't do anything on the first call because it sets the alert to `CurTime() + 3`, which makes it fail the actual ratelimit check.


I believe this is how it was intended to be set up originally - on the first call, it should still send the message.


If this is **not** the case and I missed something, just let me know 👍