### PR TITLE
Make animation parts use a stack

### DIFF
--- a/lua/pac3/core/client/parts/animation.lua
+++ b/lua/pac3/core/client/parts/animation.lua
@@ -268,15 +268,15 @@ function PART:OnShow()
 			if part ~= self then
 				part:OnStackStop()
 				part.pac_animation_stack_current = false
-			end
+				
+				if self.pac_animation_stack_contains then
+					-- Check this variable to save some perf
+					-- Remove self from stack to move to end and also prevent things from breaking because table.RemoveByValue() only removes the first instance
+					table.RemoveByValue(stack, self)
+				end
 
-			if self.pac_animation_stack_contains then
-				-- Check this variable to save some perf
-				-- Remove self from stack to move to end and also prevent things from breaking because table.RemoveByValue() only removes the first instance
-				table.RemoveByValue(stack, self)
+				table.insert(stack, self)
 			end
-
-			table.insert(stack, self)
 		end
 	else
 		ent.pac_animation_stack = {self}

--- a/lua/pac3/core/client/parts/animation.lua
+++ b/lua/pac3/core/client/parts/animation.lua
@@ -112,8 +112,8 @@ function PART:OnHide()
 	local ent = self:GetOwner()
 	if ent:IsValid() then
 		local stack = ent.pac_animation_stack
-		-- Remove self from animation stack
 		if stack then
+			-- Remove self from animation stack
 			if self.pac_animation_stack_contains then
 				table.RemoveByValue(stack, self)
 			end

--- a/lua/pac3/core/client/parts/animation.lua
+++ b/lua/pac3/core/client/parts/animation.lua
@@ -123,11 +123,21 @@ function PART:OnHide()
 			table.RemoveByValue(stack, self)
 		end
 
-		local part = stack[#stack]
-		if self.pac_animation_stack_current and part then
+		if self.pac_animation_stack_current then
 			-- This was the current animation so play the next in the stack
-			part:OnStackStart()
-			part.pac_animation_stack_current = true
+			local part = stack[#stack]
+			
+			-- Remove invalid parts
+			while part and not part:IsValid() do
+				stack[count] = nil
+				count = count - 1
+				part = stack[count]
+			end
+			
+			if part then
+				part:OnStackStart()
+				part.pac_animation_stack_current = true
+			end
 		end
 	end
 	
@@ -264,10 +274,21 @@ function PART:OnShow()
 			table.insert(stack, self)
 		else
 			-- Stop the current animation if it's not self
+			local count = #stack
 			local part = stack[count]
+			
+			-- Remove invalid parts
+			while part and not part:IsValid() do
+				stack[count] = nil
+				count = count - 1
+				part = stack[count]
+			end
+			
 			if part ~= self then
-				part:OnStackStop()
-				part.pac_animation_stack_current = false
+				if part then
+					part:OnStackStop()
+					part.pac_animation_stack_current = false
+				end
 				
 				if self.pac_animation_stack_contains then
 					-- Check this variable to save some perf

--- a/lua/pac3/core/client/parts/animation.lua
+++ b/lua/pac3/core/client/parts/animation.lua
@@ -50,16 +50,16 @@ local AnimStack = {
 
 			if part.pac_animation_stack_current then
 				-- This was the current animation so play the next in the stack
-				local part = stack[#stack]
+				local top = stack[#stack]
 			
 				-- Remove invalid parts
-				while part and not part:IsValid() do
-					part = table.remove(stack)
+				while top and not top:IsValid() do
+					top = table.remove(stack)
 				end
 			
-				if part then
-					part:OnStackStart()
-					part.pac_animation_stack_current = true
+				if top then
+					top:OnStackStart()
+					top.pac_animation_stack_current = true
 				end
 			end
 	

--- a/lua/pac3/core/client/parts/animation.lua
+++ b/lua/pac3/core/client/parts/animation.lua
@@ -128,8 +128,17 @@ function PART:OnHide()
 	if self.pac_animation_stack_current and count ~= 0 then
 		-- This was the current animation so play the next in the stack
 		local part = stack[count]
-		part:OnStackStart()
-		part.pac_animation_stack_current = true
+
+		while part ~= nil and not part:IsValid() do
+			stack[count] = nil
+			count = count - 1
+			part = stack[count]
+		end
+
+		if part then
+			part:OnStackStart()
+			part.pac_animation_stack_current = true
+		end
 	end
 end
 
@@ -264,9 +273,17 @@ function PART:OnShow()
 		-- Stop the current animation if it's not self
 		local part = stack[count]
 
+		while part ~= nil and not part:IsValid() do
+			stack[count] = nil
+			count = count - 1
+			part = stack[count]
+		end
+
 		if part ~= self then
-			part:OnStackStop()
-			part.pac_animation_stack_current = false
+			if part then
+				part:OnStackStop()
+				part.pac_animation_stack_current = false
+			end
 
 			if self.pac_animation_stack_contains then
 				-- Check this variable to save some perf

--- a/lua/pac3/core/client/parts/animation.lua
+++ b/lua/pac3/core/client/parts/animation.lua
@@ -73,7 +73,7 @@ local AnimStack = {
 		}, meta)
 	end
 }
-setmetatable(AnimStack)
+setmetatable(AnimStack, AnimStack)
 
 PART.ClassName = "animation"
 PART.ThinkTime = 0

--- a/lua/pac3/core/client/parts/animation.lua
+++ b/lua/pac3/core/client/parts/animation.lua
@@ -109,27 +109,28 @@ end
 function PART:OnHide()
 	self:OnStackStop()
 
-	local ent = self:GetOwner()
-	if ent:IsValid() then
-		local stack = ent.pac_animation_stack
-		if stack then
-			-- Remove self from animation stack
-			if self.pac_animation_stack_contains then
-				table.RemoveByValue(stack, self)
-			end
-
-			local count = #stack
-			if self.pac_animation_stack_current and count ~= 0 then
-				-- This was the current animation so play the next in the stack
-				local part = stack[count]
-				part:OnStackStart()
-				part.pac_animation_stack_current = true
-			end
-		end
-	end
-
 	self.pac_animation_stack_current = false
 	self.pac_animation_stack_contains = false
+
+	local ent = self:GetOwner()
+	if not ent:IsValid() then return end
+
+	local stack = ent.pac_animation_stack
+	if not stack then return end
+
+	-- Remove self from animation stack
+	if self.pac_animation_stack_contains then
+		table.RemoveByValue(stack, self)
+	end
+
+	local count = #stack
+
+	if self.pac_animation_stack_current and count ~= 0 then
+		-- This was the current animation so play the next in the stack
+		local part = stack[count]
+		part:OnStackStart()
+		part.pac_animation_stack_current = true
+	end
 end
 
 PART.random_seqname = ""
@@ -250,30 +251,30 @@ end
 -- Play animation and move to top of animation stack
 function PART:OnShow()
 	local ent = self:GetOwner()
-	if ent:IsValid() then
-		local stack = ent.pac_animation_stack
-		if stack then
-			local count = #stack
-			if count == 0 then
-				-- Empty stack
-				table.insert(stack, self)
-			else
-				-- Stop the current animation if it's not self
-				local part = stack[count]
-				if part ~= self then
-					part:OnStackStop()
-					part.pac_animation_stack_current = false
-					if self.pac_animation_stack_contains then
-						-- Check this variable to save some perf
-						-- Remove self from stack to move to end and also prevent things from breaking because table.RemoveByValue() only removes the first instance
-						table.RemoveByValue(stack, self)
-					end
-					table.insert(stack, self)
-				end
+	if not ent:IsValid() then return end
+
+	local stack = ent.pac_animation_stack or {}
+
+	local count = #stack
+
+	if count == 0 then
+		-- Empty stack
+		stack[count + 1] = self
+	else
+		-- Stop the current animation if it's not self
+		local part = stack[count]
+
+		if part ~= self then
+			part:OnStackStop()
+			part.pac_animation_stack_current = false
+
+			if self.pac_animation_stack_contains then
+				-- Check this variable to save some perf
+				-- Remove self from stack to move to end and also prevent things from breaking because table.RemoveByValue() only removes the first instance
+				table.RemoveByValue(stack, self)
 			end
-		else
-			-- Create stack
-			ent.pac_animation_stack = {self}
+
+			table.insert(stack, self)
 		end
 	end
 

--- a/lua/pac3/core/client/parts/animation.lua
+++ b/lua/pac3/core/client/parts/animation.lua
@@ -7,26 +7,22 @@ local AnimStack = {
 		push = function(self, part)
 			local stack = self.stack
 
-			local count = #stack
-			if count == 0 then
+			if #stack == 0 then
 				-- Empty stack
 				table.insert(stack, part)
 			else
 				-- Stop the current animation if it's not self
-				local count = #stack
-				local part2 = stack[count]
+				local top = stack[#stack]
 			
 				-- Remove invalid parts
-				while part2 and not part2:IsValid() do
-					stack[count] = nil
-					count = count - 1
-					part2 = stack[count]
+				while top and not top:IsValid() do
+					top = table.remove(stack)
 				end
 			
-				if part2 ~= part then
-					if part2 then
-						part2:OnStackStop()
-						part2.pac_animation_stack_current = false
+				if top ~= part then
+					if top then
+						top:OnStackStop()
+						top.pac_animation_stack_current = false
 					end
 				
 					if part.pac_animation_stack_contains then
@@ -54,14 +50,11 @@ local AnimStack = {
 
 			if part.pac_animation_stack_current then
 				-- This was the current animation so play the next in the stack
-				local count = #stack
-				local part = stack[count]
+				local part = stack[#stack]
 			
 				-- Remove invalid parts
 				while part and not part:IsValid() do
-					stack[count] = nil
-					count = count - 1
-					part = stack[count]
+					part = table.remove(stack)
 				end
 			
 				if part then
@@ -187,11 +180,14 @@ end
 
 -- Stop animation and remove from animation stack
 function PART:OnHide()
-	local ent = part:GetOwner()
-	if ent:IsValid() then
-		ent.pac_animation_stack = ent.pac_animation_stack or AnimStack()
-		ent.pac_animation_stack:pop(self)
+	local ent = self:GetOwner()
+	if not ent:IsValid() then return end
+	local animStack = ent.pac_animation_stack
+	if not animStack then
+		animStack = AnimStack()
+		ent.pac_animation_stack = animStack
 	end
+	animStack:pop(self)
 end
 
 PART.random_seqname = ""
@@ -312,10 +308,13 @@ end
 -- Play animation and move to top of animation stack
 function PART:OnShow()
 	local ent = self:GetOwner()
-	if ent:IsValid() then
-		ent.pac_animation_stack = ent.pac_animation_stack or AnimStack()
-		ent.pac_animation_stack:push(self)
+	if not ent:IsValid() then return end
+	local animStack = ent.pac_animation_stack
+	if not animStack then
+		animStack = AnimStack()
+		ent.pac_animation_stack = animStack
 	end
+	animStack:push(self)
 end
 
 

--- a/lua/pac3/core/client/parts/animation.lua
+++ b/lua/pac3/core/client/parts/animation.lua
@@ -125,7 +125,8 @@ function PART:OnHide()
 
 		if self.pac_animation_stack_current then
 			-- This was the current animation so play the next in the stack
-			local part = stack[#stack]
+			local count = #stack
+			local part = stack[count]
 			
 			-- Remove invalid parts
 			while part and not part:IsValid() do

--- a/lua/pac3/core/client/parts/animation.lua
+++ b/lua/pac3/core/client/parts/animation.lua
@@ -50,6 +50,14 @@ local AnimStack = {
 		return setmetatable({
 			stack = {}
 		}, meta)
+	end,
+	get = function(ent)
+		local animStack = ent.pac_animation_stack
+		if not animStack then
+			animStack = AnimStack()
+			ent.pac_animation_stack = animStack
+		end
+		return animStack
 	end
 }
 setmetatable(AnimStack, AnimStack)
@@ -161,12 +169,7 @@ end
 function PART:OnHide()
 	local ent = self:GetOwner()
 	if not ent:IsValid() then return end
-	local animStack = ent.pac_animation_stack
-	if not animStack then
-		animStack = AnimStack()
-		ent.pac_animation_stack = animStack
-	end
-	animStack:pop(self)
+	AnimStack.get(ent):pop(self)
 end
 
 PART.random_seqname = ""
@@ -288,12 +291,7 @@ end
 function PART:OnShow()
 	local ent = self:GetOwner()
 	if not ent:IsValid() then return end
-	local animStack = ent.pac_animation_stack
-	if not animStack then
-		animStack = AnimStack()
-		ent.pac_animation_stack = animStack
-	end
-	animStack:push(self)
+	AnimStack.get(ent):push(self)
 end
 
 

--- a/lua/pac3/core/client/parts/animation.lua
+++ b/lua/pac3/core/client/parts/animation.lua
@@ -12,13 +12,7 @@ local AnimStack = {
 				table.insert(stack, part)
 			else
 				-- Stop the current animation if it's not self
-				local top = stack[#stack]
-			
-				-- Remove invalid parts
-				while top and not top:IsValid() do
-					top = table.remove(stack)
-				end
-			
+				local top = self:getTop()
 				if top ~= part then
 					if top then
 						top:OnStackStop()
@@ -50,13 +44,7 @@ local AnimStack = {
 
 			if part.pac_animation_stack_current then
 				-- This was the current animation so play the next in the stack
-				local top = stack[#stack]
-			
-				-- Remove invalid parts
-				while top and not top:IsValid() do
-					top = table.remove(stack)
-				end
-			
+				local top = self:getTop()
 				if top then
 					top:OnStackStart()
 					top.pac_animation_stack_current = true
@@ -65,6 +53,14 @@ local AnimStack = {
 	
 			part.pac_animation_stack_current = false
 			part.pac_animation_stack_contains = false
+		end,
+		getTop = function(self)
+			local top = self.stack[#self.stack]
+			-- Remove invalid parts
+			while top and not top:IsValid() do
+				top = table.remove(self.stack)
+			end
+			return top
 		end
 	},
 	__call = function(meta)

--- a/lua/pac3/core/client/util.lua
+++ b/lua/pac3/core/client/util.lua
@@ -135,6 +135,17 @@ do --dev util
 
 				ent.pac_bone_parts = nil
 			end
+
+			if istable(ent.pac_animation_stack) then
+				for part in next, ent.pac_animation_stack do
+					if part:IsValid() then
+						_part = part
+						ProtectedCall(nuke_part)
+					end
+				end
+
+				ent.pac_animation_stack = nil
+			end
 		end
 	end
 

--- a/lua/pac3/core/client/util.lua
+++ b/lua/pac3/core/client/util.lua
@@ -136,16 +136,7 @@ do --dev util
 				ent.pac_bone_parts = nil
 			end
 
-			if istable(ent.pac_animation_stack) then
-				for part in next, ent.pac_animation_stack do
-					if part:IsValid() then
-						_part = part
-						ProtectedCall(nuke_part)
-					end
-				end
-
-				ent.pac_animation_stack = nil
-			end
+			ent.pac_animation_stack = nil
 		end
 	end
 


### PR DESCRIPTION
Before:  
https://user-images.githubusercontent.com/86734639/204056601-d44f08f8-e7f9-492a-bf53-909da7a1d4da.mp4  
After:  
https://user-images.githubusercontent.com/86734639/204056942-acf5d764-d383-4e03-a746-8baf5f741c77.mp4  
  
Animation parts now use a stack. When PART:OnShow() is called, it stops the current animation if there is one unless the current animation is the same PART, the part becomes the active animation, plays, and moves to the top of the stack. When PART:OnHide() is called, it stops its animation, removes itself from the stack, and plays the animation at the new top of the stack if it was the last one and if the stack is not empty. It's done in a way that will not interfere with anything outside of animation.lua.  
  
Edit: Forgot to mention, with Pac's current method, it's hard to make something like shown in the video because even if you try to use events to stop one animation and start another, if one starts and another stops on the same tick/frame/whatever, it breaks.