### PR TITLE
Fix AnimStack not existing in get()

### DIFF
--- a/lua/pac3/core/client/parts/animation.lua
+++ b/lua/pac3/core/client/parts/animation.lua
@@ -2,7 +2,8 @@ local FrameTime = FrameTime
 
 local BUILDER, PART = pac.PartTemplate("base")
 
-local AnimStack = {
+local AnimStack
+AnimStack = {
 	__index = {
 		push = function(self, part)
 			local stack = self.stack


### PR DESCRIPTION
Fixes a bug with [73e8e34](https://github.com/CapsAdmin/pac3/pull/1265/commits/73e8e34dcde5cfdcfbd74684fa5fe6f14b0a8fc3) that causes the animation part to spew errors because of `AnimStack` not existing in the context of `get(self)`.
```lua
local AnimStack = {
	__index = {
		...
		get = function(self)
			...
			animStack = AnimStack()
			...
		end
	}
}
```