### PR TITLE
fixing a small bug with autoload and button events

### DIFF
--- a/lua/pac3/editor/client/panels/editor.lua
+++ b/lua/pac3/editor/client/panels/editor.lua
@@ -311,7 +311,7 @@ function PANEL:SetBottom(pnl)
 	self.div:SetBottom(pnl)
 end
 
-pace.Focused = true
+pace.Focused = false
 
 function pace.IsFocused()
 	return pace.Focused


### PR DESCRIPTION
Bug: Button events didn't work properly in autoload pacs, before opening the pac editor (using a pac without opening the editor is indeed autoload's main purpose, or one of them at least)

Explanation: Because of this single boolean, the statement at line 1189 of the event part's code resolves to true regardless of whether it's actually true, and the statement skips the necessary lines that update the active buttons. Uninverted button events "worked" because they show stuff when the button is not pressed, so indeed, if no button is recognized then that event will detect the absence and not hide the stuff.

if ply == pac.LocalPlayer and (pace and pace.IsFocused() or gui.IsConsoleVisible()) then return end

Before we open it, the editor is not focused, so it can't be initialized to true. It should be false.