### PR TITLE
a fix for singleplayer mute footsteps

### DIFF
--- a/lua/pac3/core/client/parts/legacy/entity.lua
+++ b/lua/pac3/core/client/parts/legacy/entity.lua
@@ -89,7 +89,7 @@ function BUILDER:EntityField(name, field)
 end
 
 BUILDER:EntityField("InverseKinematics", "enable_ik")
-BUILDER:EntityField("MuteFootsteps", "hide_weapon")
+BUILDER:EntityField("MuteFootsteps", "mute_footsteps")
 BUILDER:EntityField("AnimationRate", "global_animation_rate")
 
 BUILDER:EntityField("RunSpeed", "run_speed")

--- a/lua/pac3/core/client/parts/player_config.lua
+++ b/lua/pac3/core/client/parts/player_config.lua
@@ -56,7 +56,7 @@ function BUILDER:EntityField(name, field)
 end
 
 BUILDER:EntityField("InverseKinematics", "enable_ik")
-BUILDER:EntityField("MuteFootsteps", "hide_weapon")
+BUILDER:EntityField("MuteFootsteps", "mute_footsteps")
 BUILDER:EntityField("AnimationRate", "global_animation_rate")
 BUILDER:EntityField("FallApartOnDeath", "death_physics_parts")
 BUILDER:EntityField("DeathRagdollizeParent", "death_ragdollize")

--- a/lua/pac3/core/shared/footsteps_fix.lua
+++ b/lua/pac3/core/shared/footsteps_fix.lua
@@ -2,7 +2,13 @@
 if game.SinglePlayer() then
 	if SERVER then
 		util.AddNetworkString('pac_footstep')
+		util.AddNetworkString('pac_footstep_request_state_update')
+		util.AddNetworkString('pac_signal_mute_footstep')
+		
 		hook.Add("PlayerFootstep", "footstep_fix", function(ply, pos, _, snd, vol)
+			net.Start("pac_footstep_request_state_update")
+			net.Send(ply)
+			
 			net.Start("pac_footstep")
 				net.WriteEntity(ply)
 				net.WriteVector(pos)
@@ -10,6 +16,18 @@ if game.SinglePlayer() then
 				net.WriteFloat(vol)
 			net.Broadcast()
 		end)
+		
+		net.Receive("pac_signal_mute_footstep", function(len,ply)
+			local b = net.ReadBool()
+			ply.pac_mute_footsteps = b
+			if ply.pac_mute_footsteps then
+				hook.Add("PlayerFootstep", "pac_footstep_silence", function()
+					return b
+				end)
+			else hook.Remove("PlayerFootstep", "pac_footstep_silence") end
+		end)
+		
+		
 	end
 
 	if CLIENT then
@@ -22,6 +40,11 @@ if game.SinglePlayer() then
 			if ply:IsValid() then
 				hook.Run("pac_PlayerFootstep", ply, pos, snd, vol)
 			end
+		end)
+		net.Receive("pac_footstep_request_state_update", function()
+			net.Start("pac_signal_mute_footstep")
+			net.WriteBool(LocalPlayer().pac_mute_footsteps)
+			net.SendToServer()
 		end)
 	end
 else


### PR DESCRIPTION
manually asking the client realm to network the player entity's mute footsteps bool from the client to the server realm
and the server realm then runs a footstep hook to mute