### PR TITLE
option to bypass editor's camera

### DIFF
--- a/lua/pac3/editor/client/menu_bar.lua
+++ b/lua/pac3/editor/client/menu_bar.lua
@@ -93,7 +93,8 @@ local function populate_view(menu)
 		function() pace.Call("ToggleFocus") chat.AddText("[PAC3] \"ctrl + e\" to get the editor back")
 	end):SetImage("icon16/application_delete.png")
 
-	menu:AddCVar(L"camera follow", "pac_camera_follow_entity", "1", "0"):SetImage("icon16/camera_go.png")
+	menu:AddCVar(L"camera follow: "..GetConVar("pac_camera_follow_entity"):GetInt(), "pac_camera_follow_entity", "1", "0"):SetImage("icon16/camera_go.png")
+	menu:AddCVar(L"enable editor camera: "..GetConVar("pac_enable_editor_view"):GetInt(), "pac_enable_editor_view", "1", "0"):SetImage("icon16/camera.png")
 	menu:AddOption(L"reset view position", function() pace.ResetView() end):SetImage("icon16/camera_link.png")
 	menu:AddOption(L"reset zoom", function() pace.ResetZoom() end):SetImage("icon16/magnifier.png")
 end

--- a/lua/pac3/editor/client/view.lua
+++ b/lua/pac3/editor/client/view.lua
@@ -119,6 +119,17 @@ function pace.GUIMouseReleased(mc)
 	if pace.editing_viewmodel or pace.editing_hands then return end
 
 	mcode = nil
+	if not GetConVar("pac_enable_editor_view"):GetBool() then pace.EnableView(true)
+	else
+		pac.RemoveHook("CalcView", "camera_part")
+		pac.AddHook("GUIMousePressed", "editor", pace.GUIMousePressed)
+		pac.AddHook("GUIMouseReleased", "editor", pace.GUIMouseReleased)
+		pac.AddHook("ShouldDrawLocalPlayer", "editor", pace.ShouldDrawLocalPlayer, DLib and -4 or ULib and -1 or nil)
+		pac.AddHook("CalcView", "editor", pace.CalcView, DLib and -4 or ULib and -1 or nil)
+		pac.AddHook("HUDPaint", "editor", pace.HUDPaint)
+		pac.AddHook("HUDShouldDraw", "editor", pace.HUDShouldDraw)
+		pac.AddHook("PostRenderVGUI", "editor", pace.PostRenderVGUI)
+	end
 end
 
 local function set_mouse_pos(x, y)
@@ -238,6 +249,7 @@ local function CalcDrag()
 end
 
 local follow_entity = CreateClientConVar("pac_camera_follow_entity", "0", true)
+local enable_editor_view = CreateClientConVar("pac_enable_editor_view", "1", true)
 local lastEntityPos
 
 function pace.CalcView(ply, pos, ang, fov)
@@ -331,6 +343,7 @@ function pace.EnableView(b)
 		pac.AddHook("GUIMouseReleased", "editor", pace.GUIMouseReleased)
 		pac.AddHook("ShouldDrawLocalPlayer", "editor", pace.ShouldDrawLocalPlayer, DLib and -4 or ULib and -1 or nil)
 		pac.AddHook("CalcView", "editor", pace.CalcView, DLib and -4 or ULib and -1 or nil)
+		pac.RemoveHook("CalcView", "camera_part")
 		pac.AddHook("HUDPaint", "editor", pace.HUDPaint)
 		pac.AddHook("HUDShouldDraw", "editor", pace.HUDShouldDraw)
 		pac.AddHook("PostRenderVGUI", "editor", pace.PostRenderVGUI)
@@ -342,10 +355,36 @@ function pace.EnableView(b)
 		pac.RemoveHook("GUIMouseReleased", "editor")
 		pac.RemoveHook("ShouldDrawLocalPlayer", "editor")
 		pac.RemoveHook("CalcView", "editor")
+		pac.RemoveHook("CalcView", "camera_part")
 		pac.RemoveHook("HUDPaint", "editor")
 		pac.RemoveHook("HUDShouldDraw", "editor")
 		pac.RemoveHook("PostRenderVGUI", "editor")
 		pace.SetTPose(false)
+	end
+
+	if not enable_editor_view:GetBool() then
+		local ply = LocalPlayer()
+		pac.RemoveHook("CalcView", "editor")
+		pac.AddHook("CalcView", "camera_part", function(ply, pos, ang, fov, nearz, farz)
+			for _, part in pairs(pac.GetLocalParts()) do
+				if part:IsValid() and part.ClassName == "camera" then
+					print(part)
+					part:CalcShowHide()
+					local temp = {}
+					if not part:IsHidden() then
+						pos, ang, fov, nearz, farz = part:CalcView(_,_,ply:EyeAngles())
+						temp.origin = pos
+						temp.angles = ang
+						temp.fov = fov
+						temp.znear = nearz
+						temp.zfar = farz
+						temp.drawviewer = not part.DrawViewModel
+						return temp
+					end
+				end
+			end
+		end)
+		--pac.RemoveHook("ShouldDrawLocalPlayer", "editor")
 	end
 end
 


### PR DESCRIPTION
added option "enable editor camera" with convar pac_enable_editor_view
added the value of the camera follow as a number in the label to see what state it's at without guessing or testing
it will refresh the view after mouse release
if pac_enable_editor_view = 1 pac will switch views and try to get a camera, otherwise it will take regular EyePos