### PR TITLE
adding mass property to player movement

### DIFF
--- a/lua/pac3/core/client/parts/movement.lua
+++ b/lua/pac3/core/client/parts/movement.lua
@@ -44,6 +44,7 @@ BUILDER:StartStorableVars()
 	BUILDER:SetPropertyGroup("generic")
 		ADD(PART, "Noclip", false)
 		ADD(PART, "Gravity", Vector(0, 0, -600))
+		ADD(PART, "Mass", 85)
 
 	BUILDER:SetPropertyGroup("movement")
 		ADD(PART, "SprintSpeed", 400)

--- a/lua/pac3/core/shared/movement.lua
+++ b/lua/pac3/core/shared/movement.lua
@@ -1,7 +1,7 @@
 local movementConvar = CreateConVar("pac_free_movement", -1, CLIENT and {FCVAR_REPLICATED} or {FCVAR_ARCHIVE, FCVAR_REPLICATED}, "allow players to modify movement. -1 apply only allow when noclip is allowed, 1 allow for all gamemodes, 0 to disable")
 local allowMass = CreateConVar("pac_player_movement_allow_mass", 1, CLIENT and {FCVAR_REPLICATED} or {FCVAR_ARCHIVE, FCVAR_REPLICATED}, "enables changing player mass in player movement. 1 to enable, 0 to disable", 0, 1)
 local massUpperLimit = CreateConVar("pac_player_movement_max_mass", 50000, CLIENT and {FCVAR_REPLICATED} or {FCVAR_ARCHIVE, FCVAR_REPLICATED}, "restricts the maximum mass that players can use with player movement", 85, 50000)
-local massLowerLimit = CreateConVar("pac_player_movement_min_mass", 50000, CLIENT and {FCVAR_REPLICATED} or {FCVAR_ARCHIVE, FCVAR_REPLICATED}, "restricts the minimum mass that players can use with player movement", 0, 85)
+local massLowerLimit = CreateConVar("pac_player_movement_min_mass", 0, CLIENT and {FCVAR_REPLICATED} or {FCVAR_ARCHIVE, FCVAR_REPLICATED}, "restricts the minimum mass that players can use with player movement", 0, 85)
 local massDamageScale = CreateConVar("pac_player_movement_physics_damage_scaling", 1, CLIENT and {FCVAR_REPLICATED} or {FCVAR_ARCHIVE, FCVAR_REPLICATED}, "restricts the damage scaling applied to players by modified mass values. 1 to enable, 0 to disable", 0, 1)
 
 local default = {
@@ -157,7 +157,7 @@ pac.AddHook("Move", "custom_movement", function(ply, mv)
 		end
 	end
 	
-	if (movementConvar:GetInt() == 1 and massDamageScale:GetInt() == 1 or (movementConvar:GetInt() == -1 and hook.Run("PlayerNoClip", ply, true) == true)) and massDamageScale:GetInt() == 1 then
+	if (movementConvar:GetInt() == 1 or (movementConvar:GetInt() == -1 and hook.Run("PlayerNoClip", ply, true) == true)) and massDamageScale:GetInt() == 1 then
 		scale_mass = 85/math.Clamp(self.Mass, massLowerLimit:GetFloat(), massUpperLimit:GetFloat())
 	else
 		scale_mass = 1

--- a/lua/pac3/core/shared/movement.lua
+++ b/lua/pac3/core/shared/movement.lua
@@ -1,4 +1,8 @@
 local movementConvar = CreateConVar("pac_free_movement", -1, CLIENT and {FCVAR_REPLICATED} or {FCVAR_ARCHIVE, FCVAR_REPLICATED}, "allow players to modify movement. -1 apply only allow when noclip is allowed, 1 allow for all gamemodes, 0 to disable")
+local allowMass = CreateConVar("pac_player_movement_allow_mass", 1, CLIENT and {FCVAR_REPLICATED} or {FCVAR_ARCHIVE, FCVAR_REPLICATED}, "enables changing player mass in player movement. 1 to enable, 0 to disable", 0, 1)
+local massUpperLimit = CreateConVar("pac_player_movement_max_mass", 50000, CLIENT and {FCVAR_REPLICATED} or {FCVAR_ARCHIVE, FCVAR_REPLICATED}, "restricts the maximum mass that players can use with player movement", 85, 50000)
+local massLowerLimit = CreateConVar("pac_player_movement_min_mass", 50000, CLIENT and {FCVAR_REPLICATED} or {FCVAR_ARCHIVE, FCVAR_REPLICATED}, "restricts the minimum mass that players can use with player movement", 0, 85)
+local massDamageScale = CreateConVar("pac_player_movement_physics_damage_scaling", 1, CLIENT and {FCVAR_REPLICATED} or {FCVAR_ARCHIVE, FCVAR_REPLICATED}, "restricts the damage scaling applied to players by modified mass values. 1 to enable, 0 to disable", 0, 1)
 
 local default = {
 	JumpHeight = 200,
@@ -6,6 +10,7 @@ local default = {
 	GroundFriction = 0.12,
 	AirFriction = 0.01,
 	Gravity = Vector(0,0,-600),
+	Mass = 85,
 	Noclip = false,
 	MaxGroundSpeed = 750,
 	MaxAirSpeed = 1,
@@ -35,6 +40,7 @@ if SERVER then
 		local str = net.ReadString()
 		if str == "disable" then
 			ply.pac_movement = nil
+			ply:GetPhysicsObject():SetMass(default.Mass)
 		else
 			if default[str] ~= nil then
 				local val = net.ReadType()
@@ -145,6 +151,24 @@ pac.AddHook("Move", "custom_movement", function(ply, mv)
 
 	ply:SetJumpPower(self.JumpHeight)
 
+	if SERVER then
+		if allowMass:GetInt() == 1 then
+			ply:GetPhysicsObject():SetMass(math.Clamp(self.Mass, massLowerLimit:GetFloat(), massUpperLimit:GetFloat()))
+		end
+	end
+	
+	if (movementConvar:GetInt() == 1 and massDamageScale:GetInt() == 1 or (movementConvar:GetInt() == -1 and hook.Run("PlayerNoClip", ply, true) == true)) and massDamageScale:GetInt() == 1 then
+		scale_mass = 85/math.Clamp(self.Mass, massLowerLimit:GetFloat(), massUpperLimit:GetFloat())
+	else
+		scale_mass = 1
+	end
+	
+	pac.AddHook("EntityTakeDamage", "PAC3MassDamageScale", function(target, dmginfo)
+		if (target:IsPlayer() and dmginfo:IsDamageType(DMG_CRUSH or DMG_VEHICLE)) then
+				dmginfo:ScaleDamage(scale_mass)
+		end
+	end)
+
 	if self.Noclip then
 		ply:SetMoveType(MOVETYPE_NONE)
 	else
@@ -173,7 +197,7 @@ pac.AddHook("Move", "custom_movement", function(ply, mv)
 		speed = self.DuckSpeed
 	end
 
---	speed = speed * FrameTime()
+  --speed = speed * FrameTime()
 
 	local ang = mv:GetAngles()
 	local vel = Vector()

--- a/lua/pac3/core/shared/movement.lua
+++ b/lua/pac3/core/shared/movement.lua
@@ -158,7 +158,7 @@ pac.AddHook("Move", "custom_movement", function(ply, mv)
 	end
 	
 	if (movementConvar:GetInt() == 1 or (movementConvar:GetInt() == -1 and hook.Run("PlayerNoClip", ply, true) == true)) and massDamageScale:GetInt() == 1 then
-		scale_mass = 85/math.Clamp(self.Mass, massLowerLimit:GetFloat(), massUpperLimit:GetFloat())
+		scale_mass = 85/math.Clamp(self.Mass, math.max(massLowerLimit:GetFloat(), 0.01), massUpperLimit:GetFloat())
 	else
 		scale_mass = 1
 	end


### PR DESCRIPTION
adds a property to player movement in the editor, "mass," which modifies the mass of a player's physics object
changing mass also inversely scales physics damage, and *only* physics damage
works in multiplayer and singleplayer

4 convars:
pac_player_movement_allow_mass, which enables or disables all mass changing functionality
pac_player_movement_max_mass, which sets an upper limit to allowed mass, up to 50000 (a hardcoded limit to SetMass)
pac_player_movement_min_mass, which sets a lower limit to allowed mass, as low as 0 (also a hardcoded limit)
pac_player_movement_physics_damage_scaling, which enables or disables physics damage scaling

it is also still affected by pac_free_movement, so if any player is unable to change their movement, they also cannot change their mass and will not receive damage scaling