### PR TITLE
Update http.lua

### DIFF
--- a/lua/pac3/core/shared/http.lua
+++ b/lua/pac3/core/shared/http.lua
@@ -70,6 +70,7 @@ function pac.FixUrl(url)
 		url = url:gsub([[^https?://dl.dropbox.com/]], [[https://www.dropbox.com/]])
 		url = url:gsub([[^https?://www.dropbox.com/s/(.+)%?dl%=[01]$]], [[https://dl.dropboxusercontent.com/s/%1]])
 		url = url:gsub([[^https?://www.dropbox.com/s/(.+)$]], [[https://dl.dropboxusercontent.com/s/%1]])
+		url = url:gsub([[^https?://www.dropbox.com/scl/(.+)$]], [[https://dl.dropboxusercontent.com/scl/%1]]) --Fixes new dropbox scl link formats
 		return url
 	end
 


### PR DESCRIPTION
Adds in new url sub to fix new drop box link formats not downloading correctly, this should work immediately and has no direct effect on current version, could be pushed as a hotfix for the master-branch.