### PR TITLE
Rework debug prints

### DIFF
--- a/lua/pac3/core/server/util.lua
+++ b/lua/pac3/core/server/util.lua
@@ -1,22 +1,6 @@
 local CurTime = CurTime
 local math_Clamp = math.Clamp
 
-function pac.dprint(fmt, ...)
-	if pac.debug then
-		MsgN("\n")
-		MsgN(">>>PAC3>>>")
-		MsgN(fmt:format(...))
-		if pac.debug_trace then
-			MsgN("==TRACE==")
-			debug.Trace()
-			MsgN("==TRACE==")
-		end
-		MsgN("<<<PAC3<<<")
-		MsgN("\n")
-	end
-end
-
-
 function pac.CallHook(str, ...)
 	return hook.Call("pac_" .. str, GAMEMODE, ...)
 end

--- a/lua/pac3/core/shared/util.lua
+++ b/lua/pac3/core/shared/util.lua
@@ -5,7 +5,6 @@ local PREFIX_COLOR = Color(255, 255, 0)
 local DEFAULT_TEXT_COLOR = Color(200, 200, 200)
 local BOOLEAN_COLOR = Color(33, 83, 226)
 local NUMBER_COLOR = Color(245, 199, 64)
-local STEAMID_COLOR = Color(255, 255, 255)
 local ENTITY_COLOR = Color(180, 232, 180)
 local FUNCTION_COLOR = Color(62, 106, 255)
 local TABLE_COLOR = Color(107, 200, 224)
@@ -97,12 +96,16 @@ function pac.Message(...)
 	return formatted
 end
 
+local debugLevel = CreateConVar("pac_debug", "0", FCVAR_ARCHIVE, "Debug mode for PAC3. 0 = off | 1 = debug | 2 = debug + trace", 0, 3)
+
 function pac.dprint(fmt, ...)
-	if not pac.debug then return end
+	local debugInt = debugLevel:GetInt()
+	if debugInt == 0 then return end
+
 	MsgN("\n")
 	MsgN(">>>PAC3>>>")
 	MsgN(fmt:format(...))
-	if pac.debug_trace then
+	if debugInt == 2 then
 		MsgN("==TRACE==")
 		debug.Trace()
 		MsgN("==TRACE==")

--- a/lua/pac3/editor/server/util.lua
+++ b/lua/pac3/editor/server/util.lua
@@ -1,19 +1,3 @@
-function pace.dprint(fmt, ...)
-	if pace.debug then
-		MsgN("\n")
-		MsgN(">>>PAC3>>>")
-		MsgN(fmt:format(...))
-		if pace.debug_trace then
-			MsgN("==TRACE==")
-			debug.Trace()
-			MsgN("==TRACE==")
-		end
-		MsgN("<<<PAC3<<<")
-		MsgN("\n")
-	end
-end
-
-
 function pace.CallHook(str, ...)
 	return hook.Call("pac_" .. str, GAMEMODE, ...)
 end

--- a/lua/pac3/editor/server/wear.lua
+++ b/lua/pac3/editor/server/wear.lua
@@ -112,7 +112,7 @@ function pace.SubmitPart(data, filter)
 	if istable(data.part) then
 		if last_frame == frame_number then
 			table.insert(pace.StreamQueue, {data, filter})
-			pace.dprint("queuing part %q from %s", data.part.self.Name, tostring(data.owner))
+			pac.dprint("queuing part %q from %s", data.part.self.Name, tostring(data.owner))
 			return "queue"
 		end
 	end
@@ -299,7 +299,7 @@ function pace.SubmitPart(data, filter)
 end
 
 function pace.SubmitPartNotify(data)
-	pace.dprint("submitted outfit %q from %s with %i number of children to set on %s", data.part.self.Name or "", data.owner:GetName(), table.Count(data.part.children), data.part.self.OwnerName or "")
+	pac.dprint("submitted outfit %q from %s with %i number of children to set on %s", data.part.self.Name or "", data.owner:GetName(), table.Count(data.part.children), data.part.self.OwnerName or "")
 
 	local allowed, reason = pace.SubmitPart(data)
 
@@ -321,7 +321,7 @@ function pace.SubmitPartNotify(data)
 end
 
 function pace.RemovePart(data)
-	pace.dprint("%s is removed %q", data.owner and data.owner:IsValid() and data.owner:GetName(), data.part)
+	pac.dprint("%s is removed %q", data.owner and data.owner:IsValid() and data.owner:GetName(), data.part)
 
 	if data.part == "__ALL__" then
 		pace.CallHook("RemoveOutfit", data.owner)


### PR DESCRIPTION
Debug prints seem pretty neglected in PAC3. This PR aims to make it slightly more usable.

### Summary

#### Remove `pace.dprint`
`pac.dprint` and `pace.dprint` were identical and had multiple declarations.
Instead, we just use `pac.dprint` for everything, even if it happens in the editor realm.

This also means we only have a single `pac.dprint` defined in the Shared util file.

#### Create a new `pac_debug` convar
Instead of relying on vars set on the `pac`/`pace` tables, this new convar determines if the debug prints should happen. It has three levels:
- **`0`**: Off
- **`1`**: Debug Logs
- **`2`**: Debug Logs + Trace

This closely matches the original behavior, but makes it easier to use.


### Problems

#### `pac.debug` vs. `pac_debug`
There are other cases around the addon that rely on `pac.debug` to change the behavior, so without changing those, a developer would need to set `pac.debug = true` and `pac_debug 1`.

We could change all `if pac.debug` to `if debugConVar:GetInt() > 0` (or whatever) and then we could just have the single convar.
If that's preferable, I can do that in this PR.

#### Webaudio
The webaudio file has its own `dprint` function that uses the `webaudio.debug` var to decide whether or not to print.

I left it alone because I wasn't sure why they were separate, but if you think it's within the scope of this PR, I can make it use the standard `pac.dprint` as well.