### PR TITLE
Added ability for pacSetKeyValue() E2 function to work on parts with group owner name set to world.

### DIFF
--- a/lua/pac3/extra/client/wire_expression_extension.lua
+++ b/lua/pac3/extra/client/wire_expression_extension.lua
@@ -8,6 +8,8 @@ end)
 
 local function SetKeyValue(ply, ent, unique_id, key, val)
 	local set = "Set" .. key
+	
+	if ent == game.GetWorld() then ent = pac.WorldEntity end
 
 	local part = pac.GetPartFromUniqueID(pac.Hash(ply), unique_id)
 	if not IsValid( part ) then return end


### PR DESCRIPTION
There was no way to get the clientside `pac.WorldEntity` in serverside E2. 

This change makes it so that when `world()` is passed into the `pacSetKeyValue()`, it uses `pac.WorldEntity` on the clientside.