### PR TITLE
Add size limit to E2 functions

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/custom/pac.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/pac.lua
@@ -8,20 +8,35 @@ util.AddNetworkString("pac_e2_setkeyvalue_ang")
 local enabledConvar = CreateConVar("pac_e2_ratelimit_enable", "1", {FCVAR_ARCHIVE}, "If the e2 ratelimit should be enabled.", 0, 1)
 local rate = CreateConVar("pac_e2_ratelimit_refill", "0.025", {FCVAR_ARCHIVE}, "The speed at which the ratelimit buffer refills.", 0, 1000)
 local buffer = CreateConVar("pac_e2_ratelimit_buffer", "300", {FCVAR_ARCHIVE}, "How large the ratelimit buffer should be.", 0, 1000)
+local bytes = CreateConVar("pac_e2_bytelimit", "8192", FCVAR_ARCHIVE, "Limit number of bytes sent in a single tick.", 0, 65532)
 
-local function canRunFunction(self)
+local byteLimits = WireLib.RegisterPlayerTable()
+local function canRunFunction(self, g, k, v)
+	local byteLimit = byteLimits[self.player]
+	if not byteLimit then
+		byteLimit = { CurTime(), 0 }
+		byteLimits[self.player] = byteLimit
+	end
+
+	local lim = #g + #k + #v
+	if byteLimit[1] == CurTime() then
+		lim = lim + byteLimit[2]
+	end
+	byteLimit[2] = lim
+
+	if lim >= bytes:GetInt() then return self:throw("pac3 e2 byte limit exceeded", false) end
+
 	if not enabledConvar:GetBool() then return true end
 
 	local allowed = pac.RatelimitPlayer(self.player, "e2_extension", buffer:GetInt(), rate:GetInt())
 	if not allowed then
-		E2Lib.raiseException("pac3 e2 ratelimit exceeded")
-		return false
+		return self:throw("pac3 e2 ratelimit exceeded", false)
 	end
 	return true
 end
 
 e2function void pacSetKeyValue(entity owner, string global_id, string key, string value)
-	if not canRunFunction(self) then return end
+	if not canRunFunction(self, global_id, key, value) then return end
 	net.Start("pac_e2_setkeyvalue_str")
 		net.WriteEntity(self.player)
 		net.WriteEntity(owner)
@@ -33,7 +48,7 @@ e2function void pacSetKeyValue(entity owner, string global_id, string key, strin
 end
 
 e2function void pacSetKeyValue(entity owner, string global_id, string key, number value)
-	if not canRunFunction(self) then return end
+	if not canRunFunction(self, global_id, key, "nmbr") then return end -- Workaround because I don't want to add cases for each type, 4 bytes
 	net.Start("pac_e2_setkeyvalue_num")
 		net.WriteEntity(self.player)
 		net.WriteEntity(owner)
@@ -45,25 +60,25 @@ e2function void pacSetKeyValue(entity owner, string global_id, string key, numbe
 end
 
 e2function void pacSetKeyValue(entity owner, string global_id, string key, vector value)
-	if not canRunFunction(self) then return end
+	if not canRunFunction(self, global_id, key, "vctrvctrvctr") then return end -- 4 bytes, 3 times
 	net.Start("pac_e2_setkeyvalue_vec")
 		net.WriteEntity(self.player)
 		net.WriteEntity(owner)
 		net.WriteString(global_id)
 		net.WriteString(key)
 
-		net.WriteVector(Vector(value[1], value[2], value[3]))
+		net.WriteVector(value)
 	net.Broadcast()
 end
 
 e2function void pacSetKeyValue(entity owner, string global_id, string key, angle value)
-	if not canRunFunction(self) then return end
+	if not canRunFunction(self, global_id, key, "vctrvctrvctr") then return end
 	net.Start("pac_e2_setkeyvalue_ang")
 		net.WriteEntity(self.player)
 		net.WriteEntity(owner)
 		net.WriteString(global_id)
 		net.WriteString(key)
 
-		net.WriteAngle(Angle(value[1], value[2], value[3]))
+		net.WriteAngle(value)
 	net.Broadcast()
 end


### PR DESCRIPTION
PAC3's E2 functions do not have limits on the amount of data put into them, meaning you can very easily overflow an entire server's clients. This PR adds a limit to this, and also includes small changes to fit modern Wiremod practices.

- Add size limit in bytes for PAC E2 functions, default 8192 bytes, resets every tick
- Replaces `E2Lib.raiseException` with `self:throw()` (functionally identical)
- Removes wrapping vector and angle types (unnecessary for newer version of Wiremod)