### PR TITLE
Add size limit to E2 functions

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/custom/pac.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/pac.lua
@@ -1,14 +1,11 @@
 E2Lib.RegisterExtension("pac", true)
 
-util.AddNetworkString("pac_e2_setkeyvalue_str")
-util.AddNetworkString("pac_e2_setkeyvalue_num")
-util.AddNetworkString("pac_e2_setkeyvalue_vec")
-util.AddNetworkString("pac_e2_setkeyvalue_ang")
+util.AddNetworkString("pac_e2_setkeyvalue")
 
 local enabledConvar = CreateConVar("pac_e2_ratelimit_enable", "1", {FCVAR_ARCHIVE}, "If the e2 ratelimit should be enabled.", 0, 1)
 local rate = CreateConVar("pac_e2_ratelimit_refill", "0.025", {FCVAR_ARCHIVE}, "The speed at which the ratelimit buffer refills.", 0, 1000)
 local buffer = CreateConVar("pac_e2_ratelimit_buffer", "300", {FCVAR_ARCHIVE}, "How large the ratelimit buffer should be.", 0, 1000)
-local bytes = CreateConVar("pac_e2_bytelimit", "8192", FCVAR_ARCHIVE, "Limit number of bytes sent in a single tick.", 0, 65532)
+local bytes = CreateConVar("pac_e2_bytelimit", "2048", FCVAR_ARCHIVE, "Limit number of bytes sent in a single tick.", 0, 65532)
 
 local byteLimits = WireLib.RegisterPlayerTable()
 local function canRunFunction(self, g, k, v)
@@ -35,50 +32,57 @@ local function canRunFunction(self, g, k, v)
 	return true
 end
 
+--- Domain-specific type IDs for networking E2 keyvalues
+---@alias pac.E2.NetID
+---| 0 # String
+---| 1 # Number
+---| 2 # Vector
+---| 3 # Angle
+
 e2function void pacSetKeyValue(entity owner, string global_id, string key, string value)
 	if not canRunFunction(self, global_id, key, value) then return end
-	net.Start("pac_e2_setkeyvalue_str")
+	net.Start("pac_e2_setkeyvalue")
 		net.WriteEntity(self.player)
 		net.WriteEntity(owner)
 		net.WriteString(global_id)
 		net.WriteString(key)
-
+		net.WriteUInt(0, 2)
 		net.WriteString(value)
 	net.Broadcast()
 end
 
 e2function void pacSetKeyValue(entity owner, string global_id, string key, number value)
 	if not canRunFunction(self, global_id, key, "nmbr") then return end -- Workaround because I don't want to add cases for each type, 4 bytes
-	net.Start("pac_e2_setkeyvalue_num")
+	net.Start("pac_e2_setkeyvalue")
 		net.WriteEntity(self.player)
 		net.WriteEntity(owner)
 		net.WriteString(global_id)
 		net.WriteString(key)
-
+		net.WriteUInt(1, 2)
 		net.WriteFloat(value)
 	net.Broadcast()
 end
 
 e2function void pacSetKeyValue(entity owner, string global_id, string key, vector value)
 	if not canRunFunction(self, global_id, key, "vctrvctrvctr") then return end -- 4 bytes, 3 times
-	net.Start("pac_e2_setkeyvalue_vec")
+	net.Start("pac_e2_setkeyvalue")
 		net.WriteEntity(self.player)
 		net.WriteEntity(owner)
 		net.WriteString(global_id)
 		net.WriteString(key)
-
+		net.WriteUInt(2, 2)
 		net.WriteVector(value)
 	net.Broadcast()
 end
 
 e2function void pacSetKeyValue(entity owner, string global_id, string key, angle value)
 	if not canRunFunction(self, global_id, key, "vctrvctrvctr") then return end
-	net.Start("pac_e2_setkeyvalue_ang")
+	net.Start("pac_e2_setkeyvalue")
 		net.WriteEntity(self.player)
 		net.WriteEntity(owner)
 		net.WriteString(global_id)
 		net.WriteString(key)
-
+		net.WriteUInt(3, 2)
 		net.WriteAngle(value)
 	net.Broadcast()
 end

--- a/lua/entities/gmod_wire_expression2/core/custom/pac.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/pac.lua
@@ -8,20 +8,35 @@ util.AddNetworkString("pac_e2_setkeyvalue_ang")
 local enabledConvar = CreateConVar("pac_e2_ratelimit_enable", "1", {FCVAR_ARCHIVE}, "If the e2 ratelimit should be enabled.", 0, 1)
 local rate = CreateConVar("pac_e2_ratelimit_refill", "0.025", {FCVAR_ARCHIVE}, "The speed at which the ratelimit buffer refills.", 0, 1000)
 local buffer = CreateConVar("pac_e2_ratelimit_buffer", "300", {FCVAR_ARCHIVE}, "How large the ratelimit buffer should be.", 0, 1000)
+local bytes = CreateConVar("pac_e2_bytelimit", "8192", FCVAR_ARCHIVE, "Limit number of bytes sent in a single tick.", 0, 65532)
 
-local function canRunFunction(self)
+local byteLimits = WireLib.RegisterPlayerTable()
+local function canRunFunction(self, g, k, v)
+	local byteLimit = byteLimits[self.player]
+	if not byteLimit then
+		byteLimit = { CurTime(), 0 }
+		byteLimits[self.player] = byteLimit
+	end
+
+	local lim = #g + #k + #v
+	if byteLimit[1] == CurTime() then
+		lim = lim + byteLimit[2]
+	end
+	byteLimit[2] = lim
+
+	if lim >= bytes:GetInt() then return self:throw("pac3 e2 byte limit exceeded", false) end
+
 	if not enabledConvar:GetBool() then return true end
 
 	local allowed = pac.RatelimitPlayer(self.player, "e2_extension", buffer:GetInt(), rate:GetInt())
 	if not allowed then
-		E2Lib.raiseException("pac3 e2 ratelimit exceeded")
-		return false
+		return self:throw("pac3 e2 ratelimit exceeded", false)
 	end
 	return true
 end
 
 e2function void pacSetKeyValue(entity owner, string global_id, string key, string value)
-	if not canRunFunction(self) then return end
+	if not canRunFunction(self, global_id, key, value) then return end
 	net.Start("pac_e2_setkeyvalue_str")
 		net.WriteEntity(self.player)
 		net.WriteEntity(owner)
@@ -33,7 +48,7 @@ e2function void pacSetKeyValue(entity owner, string global_id, string key, strin
 end
 
 e2function void pacSetKeyValue(entity owner, string global_id, string key, number value)
-	if not canRunFunction(self) then return end
+	if not canRunFunction(self, global_id, key, "nmbr") then return end -- Workaround because I don't want to add cases for each type, 4 bytes
 	net.Start("pac_e2_setkeyvalue_num")
 		net.WriteEntity(self.player)
 		net.WriteEntity(owner)
@@ -45,25 +60,25 @@ e2function void pacSetKeyValue(entity owner, string global_id, string key, numbe
 end
 
 e2function void pacSetKeyValue(entity owner, string global_id, string key, vector value)
-	if not canRunFunction(self) then return end
+	if not canRunFunction(self, global_id, key, "vctrvctrvctr") then return end -- 4 bytes, 3 times
 	net.Start("pac_e2_setkeyvalue_vec")
 		net.WriteEntity(self.player)
 		net.WriteEntity(owner)
 		net.WriteString(global_id)
 		net.WriteString(key)
 
-		net.WriteVector(Vector(value[1], value[2], value[3]))
+		net.WriteVector(value)
 	net.Broadcast()
 end
 
 e2function void pacSetKeyValue(entity owner, string global_id, string key, angle value)
-	if not canRunFunction(self) then return end
+	if not canRunFunction(self, global_id, key, "vctrvctrvctr") then return end
 	net.Start("pac_e2_setkeyvalue_ang")
 		net.WriteEntity(self.player)
 		net.WriteEntity(owner)
 		net.WriteString(global_id)
 		net.WriteString(key)
 
-		net.WriteAngle(Angle(value[1], value[2], value[3]))
+		net.WriteAngle(value)
 	net.Broadcast()
 end

--- a/lua/entities/gmod_wire_expression2/core/custom/pac.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/pac.lua
@@ -3,8 +3,8 @@ E2Lib.RegisterExtension("pac", true)
 util.AddNetworkString("pac_e2_setkeyvalue")
 
 local enabledConvar = CreateConVar("pac_e2_ratelimit_enable", "1", FCVAR_ARCHIVE, "If the e2 ratelimit should be enabled.", 0, 1)
-local rate = CreateConVar("pac_e2_ratelimit_refill", "0.025", FCVAR_ARCHIVE, "The speed at which the ratelimit buffer refills.", 0, 1000)
-local buffer = CreateConVar("pac_e2_ratelimit_buffer", "300", FCVAR_ARCHIVE, "How large the ratelimit buffer should be.", 0, 1000)
+local rate = CreateConVar("pac_e2_ratelimit_refill", "0.025", FCVAR_ARCHIVE, "The amount at which the ratelimit buffer refills per second.", 0, 1000)
+local buffer = CreateConVar("pac_e2_ratelimit_buffer", "300", FCVAR_ARCHIVE, "How many PAC E2 operations are allowed before the rate limit is hit.", 0, 1000)
 local bytes = CreateConVar("pac_e2_bytelimit", "2048", FCVAR_ARCHIVE, "Limit number of bytes sent per second for PAC E2 messages.", 0, 65532)
 
 local byteLimits = WireLib.RegisterPlayerTable()

--- a/lua/entities/gmod_wire_expression2/core/custom/pac.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/pac.lua
@@ -28,7 +28,7 @@ local function canRunFunction(self, g, k, v)
 
 	if not enabledConvar:GetBool() then return true end
 
-	local allowed = pac.RatelimitPlayer(self.player, "e2_extension", buffer:GetInt(), rate:GetInt())
+	local allowed = pac.RatelimitPlayer(self.player, "e2_extension", buffer:GetInt(), rate:GetFloat())
 	if not allowed then
 		return self:throw("pac3 e2 ratelimit exceeded", false)
 	end

--- a/lua/entities/gmod_wire_expression2/core/custom/pac.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/pac.lua
@@ -2,22 +2,25 @@ E2Lib.RegisterExtension("pac", true)
 
 util.AddNetworkString("pac_e2_setkeyvalue")
 
-local enabledConvar = CreateConVar("pac_e2_ratelimit_enable", "1", {FCVAR_ARCHIVE}, "If the e2 ratelimit should be enabled.", 0, 1)
-local rate = CreateConVar("pac_e2_ratelimit_refill", "0.025", {FCVAR_ARCHIVE}, "The speed at which the ratelimit buffer refills.", 0, 1000)
-local buffer = CreateConVar("pac_e2_ratelimit_buffer", "300", {FCVAR_ARCHIVE}, "How large the ratelimit buffer should be.", 0, 1000)
-local bytes = CreateConVar("pac_e2_bytelimit", "2048", FCVAR_ARCHIVE, "Limit number of bytes sent in a single tick.", 0, 65532)
+local enabledConvar = CreateConVar("pac_e2_ratelimit_enable", "1", FCVAR_ARCHIVE, "If the e2 ratelimit should be enabled.", 0, 1)
+local rate = CreateConVar("pac_e2_ratelimit_refill", "0.025", FCVAR_ARCHIVE, "The speed at which the ratelimit buffer refills.", 0, 1000)
+local buffer = CreateConVar("pac_e2_ratelimit_buffer", "300", FCVAR_ARCHIVE, "How large the ratelimit buffer should be.", 0, 1000)
+local bytes = CreateConVar("pac_e2_bytelimit", "2048", FCVAR_ARCHIVE, "Limit number of bytes sent per second for PAC E2 messages.", 0, 65532)
 
 local byteLimits = WireLib.RegisterPlayerTable()
 local function canRunFunction(self, g, k, v)
 	local byteLimit = byteLimits[self.player]
+	local ct = CurTime()
 	if not byteLimit then
-		byteLimit = { CurTime(), 0 }
+		byteLimit = { ct + 1, 0 }
 		byteLimits[self.player] = byteLimit
 	end
 
 	local lim = #g + #k + #v
-	if byteLimit[1] == CurTime() then
+	if ct < byteLimit[1] then
 		lim = lim + byteLimit[2]
+	else
+		byteLimit[1] = ct + 1
 	end
 	byteLimit[2] = lim
 
@@ -41,7 +44,7 @@ end
 
 e2function void pacSetKeyValue(entity owner, string global_id, string key, string value)
 	if not canRunFunction(self, global_id, key, value) then return end
-	net.Start("pac_e2_setkeyvalue")
+	net.Start("pac_e2_setkeyvalue", true)
 		net.WriteEntity(self.player)
 		net.WriteEntity(owner)
 		net.WriteString(global_id)
@@ -53,7 +56,7 @@ end
 
 e2function void pacSetKeyValue(entity owner, string global_id, string key, number value)
 	if not canRunFunction(self, global_id, key, "nmbr") then return end -- Workaround because I don't want to add cases for each type, 4 bytes
-	net.Start("pac_e2_setkeyvalue")
+	net.Start("pac_e2_setkeyvalue", true)
 		net.WriteEntity(self.player)
 		net.WriteEntity(owner)
 		net.WriteString(global_id)
@@ -65,7 +68,7 @@ end
 
 e2function void pacSetKeyValue(entity owner, string global_id, string key, vector value)
 	if not canRunFunction(self, global_id, key, "vctrvctrvctr") then return end -- 4 bytes, 3 times
-	net.Start("pac_e2_setkeyvalue")
+	net.Start("pac_e2_setkeyvalue", true)
 		net.WriteEntity(self.player)
 		net.WriteEntity(owner)
 		net.WriteString(global_id)
@@ -77,7 +80,7 @@ end
 
 e2function void pacSetKeyValue(entity owner, string global_id, string key, angle value)
 	if not canRunFunction(self, global_id, key, "vctrvctrvctr") then return end
-	net.Start("pac_e2_setkeyvalue")
+	net.Start("pac_e2_setkeyvalue", true)
 		net.WriteEntity(self.player)
 		net.WriteEntity(owner)
 		net.WriteString(global_id)

--- a/lua/pac3/extra/client/wire_expression_extension.lua
+++ b/lua/pac3/extra/client/wire_expression_extension.lua
@@ -31,14 +31,24 @@ local function SetKeyValue(ply, ent, unique_id, key, val)
 	end
 end
 
-net.Receive("pac_e2_setkeyvalue_str", function()
+net.Receive("pac_e2_setkeyvalue", function()
 	local ply = net.ReadEntity()
 
 	if ply:IsValid() then
 		local ent = net.ReadEntity()
 		local id = net.ReadString()
 		local key = net.ReadString()
-		local val = net.ReadString()
+		local type = net.ReadUInt(2) ---@type pac.E2.NetID
+		local val
+		if type == 0 then
+			val = net.ReadString()
+		elseif type == 1 then
+			val = net.ReadFloat()
+		elseif type == 2 then
+			val = net.ReadVector()
+		else
+			val = net.ReadAngle()
+		end
 
 		SetKeyValue(ply, ent, id, key, val)
 	end


### PR DESCRIPTION
See #1347

- Changed description on `pac_e2_ratelimit_buffer` and `pac_e2_ratelimit_refill` to be more descriptive
- Fixed ratelimit used `GetInt` instead of `GetFloat` causing instant limit hits with values below 1

----
PAC3's E2 functions do not have limits on the amount of data put into them, meaning you can very easily overflow an entire server's clients. This PR adds a limit to this, and also includes small changes to fit modern Wiremod practices.

- Add size limit in bytes for PAC E2 functions, default 2048 bytes, resets every tick
- Replaces `E2Lib.raiseException` with `self:throw()` (functionally identical)
- Removes wrapping vector and angle types (unnecessary for newer version of Wiremod)