### PR TITLE
Use player.Iterator() instead of player.GetAll()

### DIFF
--- a/lua/pac3/core/client/part_pool.lua
+++ b/lua/pac3/core/client/part_pool.lua
@@ -250,7 +250,7 @@ function pac.UnhookEntityRender(ent, part)
 end
 
 pac.AddHook("Think", "events", function()
-	for _, ply in ipairs(player.GetAll()) do
+	for _, ply in player.Iterator() do
 		if not ent_parts[ply] then continue end
 		if pac.IsEntityIgnored(ply) then continue end
 

--- a/lua/pac3/editor/client/init.lua
+++ b/lua/pac3/editor/client/init.lua
@@ -304,7 +304,7 @@ do
 	local up = Vector(0,0,10000)
 
 	hook.Add("HUDPaint", "pac_in_editor", function()
-		for _, ply in ipairs(player.GetAll()) do
+		for _, ply in player.Iterator() do
 			if ply ~= pac.LocalPlayer and ply:GetNW2Bool("pac_in_editor") then
 
 				if showCameras:GetInt() == 1 then


### PR DESCRIPTION
It will help to reduce the senseless number of player.GetAll() calls and reduce CPU load