### PR TITLE
Use player.Iterator() instead of player.GetAll() (Development branch)

### DIFF
--- a/lua/pac3/core/client/part_pool.lua
+++ b/lua/pac3/core/client/part_pool.lua
@@ -251,7 +251,7 @@ function pac.UnhookEntityRender(ent, part)
 end
 
 pac.AddHook("Think", "events", function()
-	for _, ply in ipairs(player.GetAll()) do
+	for _, ply in player.Iterator() do
 		if not ent_parts[ply] then continue end
 		if pac.IsEntityIgnored(ply) then continue end
 

--- a/lua/pac3/editor/client/init.lua
+++ b/lua/pac3/editor/client/init.lua
@@ -314,7 +314,7 @@ do
 	local up = Vector(0,0,10000)
 
 	pac.AddHook("HUDPaint", "in_editor", function()
-		for _, ply in ipairs(player.GetAll()) do
+		for _, ply in player.Iterator() do
 			if ply ~= pac.LocalPlayer and ply:GetNW2Bool("pac_in_editor") then
 
 				if showCameras:GetInt() == 1 then


### PR DESCRIPTION
It will help to reduce the senseless number of player.GetAll() calls and reduce CPU load