### PR TITLE
viewer_steamid improvements

### DIFF
--- a/lua/pac3/core/client/parts/event.lua
+++ b/lua/pac3/core/client/parts/event.lua
@@ -2898,7 +2898,7 @@ PART.OldEvents = {
 		tutorial = "activates when the local player has the steamID specified",
 		arguments = {{find = "string"}, {include_owner = "boolean"}},
 		callback = function(self, ent, find, include_owner)
-			local owner = self:GetOwner()
+			local owner = self:GetPlayerOwner()
 			if include_owner and owner:IsValid() then
 				find = find .. ";" .. owner:SteamID()
 			end

--- a/lua/pac3/core/client/parts/event.lua
+++ b/lua/pac3/core/client/parts/event.lua
@@ -2898,8 +2898,9 @@ PART.OldEvents = {
 		tutorial = "activates when the local player has the steamID specified",
 		arguments = {{find = "string"}, {include_owner = "boolean"}},
 		callback = function(self, ent, find, include_owner)
-			if include_owner then
-				find = find .. ";" .. self:GetOwner():SteamID()
+			local owner = self:GetOwner()
+			if include_owner and owner:IsValid() then
+				find = find .. ";" .. owner:SteamID()
 			end
 
 			return self:StringOperator(pac.LocalPlayer:SteamID(), find)


### PR DESCRIPTION
Uses the correct owner method and checks it's validity for the viewer_steamid event type. Checking the validity probably isn't necessary (?) but it also doesn't hurt to include