### PR TITLE
Fix recent HTTP timeouts

### DIFF
--- a/lua/pac3/core/shared/http.lua
+++ b/lua/pac3/core/shared/http.lua
@@ -57,7 +57,8 @@ local function http(method, url, headers, cb, failcb)
 			else
 				pac.Message("_G.HTTP error: " .. err)
 			end
-		end
+		end,
+		timeout = 300
 	})
 end
 


### PR DESCRIPTION
Fixes #1419
Until recently, the game's HTTP request function had a nonfunctional timeout, which was [recently fixed](https://commits.facepunch.com/543164). As a result, players suddenly began experiencing timeouts during outfit asset downloads. This PR bumps the default 60 second timeout to a saner value to accommodate players with lower bandwidth.