### PR TITLE
Damage Zones need nil checks

### DIFF
--- a/lua/pac3/core/client/parts/damage_zone.lua
+++ b/lua/pac3/core/client/parts/damage_zone.lua
@@ -353,7 +353,7 @@ local function TryAttachPartToAnEntity(self,group,parent_ent,marker_ent,killing)
 			end
 			group:SetOwnerName(parent_ent:EntIndex())
 		end
-		
+
 	else
 		group:SetOwner(marker_ent)
 	end
@@ -363,7 +363,7 @@ local function FreeSpotInStack(owner)
 	owner.hitparts = owner.hitparts or {}
 	owner.hitparts_freespots = owner.hitparts_freespots or {}
 	for i=1,50,1 do
-		if owner.hitparts_freespots[i] == nil then owner.hitparts_freespots[i] = false return i end 
+		if owner.hitparts_freespots[i] == nil then owner.hitparts_freespots[i] = false return i end
 		if owner.hitparts_freespots[i] ~= false then
 			if owner.hitparts[i] then
 				if not owner.hitparts[i].active then
@@ -441,7 +441,7 @@ function PART:AddHitMarkerToStack(index, owner, ent, part_uid, ent_id, parent_en
 		owner.hitparts[index] = {active = true, specimen_part = returned_part, hitmarker_id = ent_id, template_uid = part_uid, csent = ent, parent_ent = parent_ent}
 		TryAttachPartToAnEntity(self,existingpart,parent_ent,ent, killing)
 	end
-	
+
 
 	return returned_part
 end
@@ -496,13 +496,13 @@ function PART:AssignFloatingPartToEntity(index, part, owner, ent, parent_ent, te
 	group:SetShowInEditor(false)
 
 	TryAttachPartToAnEntity(self,group,parent_ent,ent)
-	
-	
+
+
 	timer.Simple(0, function() group:SetHide(false) part2:SetHide(false) group:CallRecursive("Think") group:CallRecursive("CalcShowHide") end)
-	
-	
+
+
 	--print(parent_ent, group:IsHidden(), part2:IsHidden())
-	
+
 	owner.hitparts_freespots[index] = false
 	--print(group, "assigned to " .. marker_id .. " / " .. parent_ent:EntIndex())
 
@@ -798,6 +798,12 @@ net.Receive("pac_hit_results", function(len)
 	local pos = self:GetWorldPosition()
 	local owner = self:GetPlayerOwner()
 
+	--START_BS_MOD
+	--Octo 3/32026
+	--Purpose: Set off a client hook so we know what a damage zone did for crediting in the killcam.
+	hook.Run("BS_pacHitResults", owner, uid, self, pos, hit, kill, highest_dmg, do_ents_feedback, ents_hit, ents_kill)
+	--END_BS_MOD
+
 	self.lag_risk = table.Count(ents_hit) > 15
 
 	local function ValidSound(part)
@@ -880,7 +886,7 @@ net.Receive("pac_hit_results", function(len)
 		end
 
 		local free_spot = FreeSpotInStack(owner)
-		
+
 		if free_spot then
 			if part:IsValid() then --self:AttachToEntity(part, ent, parent_ent, global_hitmarker_CSEnt_seed)
 				--print("free spot should be " .. free_spot)

--- a/lua/pac3/core/client/parts/damage_zone.lua
+++ b/lua/pac3/core/client/parts/damage_zone.lua
@@ -180,6 +180,8 @@ function PART:LaunchAuditAndEnforceSoftBan(amount, reason)
 		return
 	end
 	local owner = self:GetPlayerOwner()
+	if not IsValid(owner) then return end
+
 	if owner ~= LocalPlayer() then return end
 	owner.stop_hit_markers_admonishment_count = owner.stop_hit_markers_admonishment_count or 1
 	owner.stop_hit_markers_admonishment_message_up = false
@@ -513,6 +515,8 @@ function PART:ClearHitMarkers()
 		if IsValid(part) then part:GetRootOwner():Remove() end
 	end
 	local ply = self:GetPlayerOwner()
+	if not IsValid(ply) then return end --CMON CEDRIC. IT'S THIS EASY
+
 	if ply.hitparts then
 		for i,v in pairs(ply.hitparts) do
 			v.specimen_part:Remove()
@@ -741,12 +745,15 @@ function PART:LegacyAttachToEntity(part, ent)
 
 	local tbl = part:ToTable()
 
-	local group = pac.CreatePart("group", self:GetPlayerOwner())
+	local ply = self:GetPlayerOwner()
+	if not IsValid(ply) then return end
+
+	local group = pac.CreatePart("group", ply)
 	table.insert(hitparts_dump, {self, group, ent})
 	self.force_cleanup_hitparts = CurTime() + math.max(self.HitMarkerLifetime, self.KillMarkerLifetime)
 	group:SetShowInEditor(false)
 
-	local part_clone = pac.CreatePart(tbl.self.ClassName, self:GetPlayerOwner(), tbl, tostring(tbl))
+	local part_clone = pac.CreatePart(tbl.self.ClassName, ply, tbl, tostring(tbl))
 	group:AddChild(part_clone)
 
 	group:SetOwner(ent)
@@ -797,6 +804,7 @@ net.Receive("pac_hit_results", function(len)
 
 	local pos = self:GetWorldPosition()
 	local owner = self:GetPlayerOwner()
+	if not IsValid(owner) then return end
 
 	--START_BS_MOD
 	--Octo 3/32026
@@ -1026,6 +1034,10 @@ function PART:PreviewHitbox()
 		if not self.Preview then pac.RemoveHook(self.RenderingHook, "pace_draw_hitbox"..self.UniqueID) end
 		if not IsValid(self) then pac.RemoveHook(self.RenderingHook, "pace_draw_hitbox"..self.UniqueID) end
 		self:GetWorldPosition()
+
+		local ply = self:GetPlayerOwner()
+		if not IsValid(ply) then return end
+
 		if self.HitboxMode == "Box" then
 			local mins =  Vector(-self.Radius, -self.Radius, -self.Length)
 			local maxs = Vector(self.Radius, self.Radius, self.Length)
@@ -1047,7 +1059,8 @@ function PART:PreviewHitbox()
 			cam.PushModelMatrix( mat )
 			obj:Draw()
 			cam.PopModelMatrix()
-			if LocalPlayer() == self:GetPlayerOwner() then
+
+			if LocalPlayer() == ply then
 				if self.Radius ~= 0 then
 					local sides = self.Detail
 					if self.Detail < 1 then sides = 1 end
@@ -1122,7 +1135,7 @@ function PART:PreviewHitbox()
 			cam.PushModelMatrix( mat )
 			obj:Draw()
 			cam.PopModelMatrix()
-			if LocalPlayer() == self:GetPlayerOwner() then
+			if LocalPlayer() == ply then
 				if self.Radius ~= 0 then
 					local sides = self.Detail
 					if self.Detail < 1 then sides = 1 end


### PR DESCRIPTION
added some nil checks to a few functions. pac3 would spam errors in console from 'Tried to use a NULL entity!' this should fix that issue
<img width="1002" height="137" alt="image_2026-03-21_140121467" src="https://github.com/user-attachments/assets/7e2c4dbf-301e-450f-bc47-ea952a227bca" />
