### PR TITLE
Simple ranger filtering

### DIFF
--- a/lua/pac3/core/client/parts/event.lua
+++ b/lua/pac3/core/client/parts/event.lua
@@ -1182,7 +1182,12 @@ PART.OldEvents = {
 		arguments = {{distance = "number"}, {compare = "number"}, {npcs_and_players_only = "boolean"}, {ignore_you = "boolean"}, {ignore_viewer = "boolean"}, {ignore_players = "boolean"}, {ignore_npcs = "boolean"}},
 		userdata = {
 			{default = 15, editor_panel = "ranger", ranger_property = "distance"},
-			{default = 5, editor_panel = "ranger", ranger_property = "compare"}
+			{default = 5, editor_panel = "ranger", ranger_property = "compare"},
+			{default = false},
+			{default = false},
+			{default = false},
+			{default = false},
+			{default = false},
 		},
 		callback = function(self, ent, distance, compare, npcs_and_players_only, ignore_you, ignore_viewer, ignore_players, ignore_npcs)
 

--- a/lua/pac3/core/client/parts/event.lua
+++ b/lua/pac3/core/client/parts/event.lua
@@ -1202,7 +1202,7 @@ PART.OldEvents = {
 					-- NPCs need a function filter since there isn't a clean and *performant* way to get all of them into a table.
 					filter = function(e)
 						if e == ent then return false end
-						if e:IsNPC() then return false end
+						if e:IsNPC() or e:IsNextBot() then return false end
 						if ignore_you and e == ownerPly then return false end
 						if ignore_viewer and e == localPly then return false end
 						if ignore_players and e:IsPlayer() then return false end
@@ -1232,7 +1232,7 @@ PART.OldEvents = {
 					filter = filter,
 				})
 
-				if npcs_and_players_only and (not res.Entity:IsPlayer() and not res.Entity:IsNPC()) then
+				if npcs_and_players_only and (not res.Entity:IsPlayer() and not res.Entity:IsNPC() and not res.Entity:IsNextBot()) then
 					return false
 				end
 

--- a/lua/pac3/core/client/parts/event.lua
+++ b/lua/pac3/core/client/parts/event.lua
@@ -1179,12 +1179,12 @@ PART.OldEvents = {
 	ranger = {
 		operator_type = "number", preferred_operator = "below",
 		tutorial_explanation = "ranger looks in a line to see if something is in front (red arrow) of its host's (parent) model;\ndetected things could be found before(below) or beyond(above) the distance defined in compare;\nthe event will only look as far as the distance defined in distance",
-		arguments = {{distance = "number"}, {compare = "number"}, {npcs_and_players_only = "boolean"}},
+		arguments = {{distance = "number"}, {compare = "number"}, {npcs_and_players_only = "boolean"}, {ignore_you = "boolean"}, {ignore_viewer = "boolean"}, {ignore_players = "boolean"}, {ignore_npcs = "boolean"}},
 		userdata = {
 			{default = 15, editor_panel = "ranger", ranger_property = "distance"},
 			{default = 5, editor_panel = "ranger", ranger_property = "compare"}
 		},
-		callback = function(self, ent, distance, compare, npcs_and_players_only)
+		callback = function(self, ent, distance, compare, npcs_and_players_only, ignore_you, ignore_viewer, ignore_players, ignore_npcs)
 
 			local parent = self:GetParentEx()
 
@@ -1193,10 +1193,43 @@ PART.OldEvents = {
 				distance = distance or 1
 				compare = compare or 0
 
+				local filter = ent
+
+				if ignore_npcs then
+					local ownerPly = self:GetPlayerOwner() -- Has to traverse root, slow.
+					local localPly = LocalPlayer()
+
+					-- NPCs need a function filter since there isn't a clean and *performant* way to get all of them into a table.
+					filter = function(e)
+						if e == ent then return false end
+						if e:IsNPC() then return false end
+						if ignore_you and e == ownerPly then return false end
+						if ignore_viewer and e == localPly then return false end
+						if ignore_players and e:IsPlayer() then return false end
+
+						return true
+					end
+				elseif ignore_you or ignore_viewer or ignore_players then
+					-- Make a table for other ignores, more performant than a function.
+					filter = {ent}
+
+					if ignore_players then
+						table.Add(filter, player.GetAll())
+					else -- Other options are redundant if ignoring players.
+						if ignore_you then
+							table.insert(filter, self:GetPlayerOwner())
+						end
+
+						if ignore_viewer then
+							table.insert(filter, LocalPlayer())
+						end
+					end
+				end
+
 				local res = util.TraceLine({
 					start = parent:GetWorldPosition(),
 					endpos = parent:GetWorldPosition() + parent:GetWorldAngles():Forward() * distance,
-					filter = ent,
+					filter = filter,
 				})
 
 				if npcs_and_players_only and (not res.Entity:IsPlayer() and not res.Entity:IsNPC()) then


### PR DESCRIPTION
Adds four new boolean options to the ranger event, allowing the trace to ignore the pac owner player, the local player, all players, and/or all npcs. Also makes the npc check respect nextbots.
<img width="186" height="57" alt="image" src="https://github.com/user-attachments/assets/4486b163-bc20-433e-ac23-0293eaf2391b" />

Without this, the only way to filter out your own player entity is by having the event parented to yourself, which prevents you from controlling its position or angle.